### PR TITLE
Fix: Add missing src/app.html and update troubleshooting guide

### DIFF
--- a/frontend/TROUBLESHOOTING_GUIDE.md
+++ b/frontend/TROUBLESHOOTING_GUIDE.md
@@ -1,0 +1,109 @@
+# Troubleshooting Guide: Resolving '__SERVER__/internal.js' Error
+
+This guide provides steps to resolve the SvelteKit error: `Pre-transform error: Failed to load url __SERVER__/internal.js` or `Error: Cannot find module '__SERVER__/internal.js'`.
+
+## Root Cause Analysis
+
+The error indicates that SvelteKit's build process is failing to generate or locate a critical internal file (`internal.js`) required for its server-side operations. The investigation points to an **incomplete or corrupted `node_modules` directory** as the most probable cause.
+
+Key findings from the analysis:
+- The file `frontend/.svelte-kit/generated/server/internal.js` was confirmed to be missing.
+- Core SvelteKit runtime files within `node_modules` also appeared to be missing or inaccessible, suggesting a deeper issue with dependency installation.
+- Configuration files (`vite.config.js`, `svelte.config.js`, `package.json`) were found to be standard and correctly set up.
+- The automated tooling environment has limitations preventing direct fixes to `node_modules` (e.g., running `npm install` directly within the automated subtask).
+
+## Recommended Steps to Resolve
+
+These steps should be performed in your **local development environment**:
+
+1.  **Navigate to the Frontend Directory:**
+    Open your terminal and change to the project's frontend directory:
+    ```bash
+    cd path/to/your/project/frontend
+    ```
+
+2.  **Clean Dependency Installation (Crucial):**
+    *   **Delete `node_modules`:**
+        ```bash
+        rm -rf node_modules  # On macOS/Linux
+        # On Windows, you can use: rmdir /s /q node_modules
+        ```
+    *   **Delete Lock File:**
+        If you use npm, delete `package-lock.json`:
+        ```bash
+        rm -f package-lock.json
+        ```
+        If you use yarn, delete `yarn.lock`:
+        ```bash
+        rm -f yarn.lock
+        ```
+    *   **Reinstall Dependencies:**
+        If you use npm:
+        ```bash
+        npm install
+        ```
+        If you use yarn:
+        ```bash
+        yarn install
+        ```
+        Carefully observe the output for any errors during this installation process.
+
+3.  **Clean SvelteKit Build Cache:**
+    *   After successfully reinstalling dependencies, delete the `.svelte-kit` directory:
+        ```bash
+        rm -rf .svelte-kit # On macOS/Linux
+        # On Windows, you can use: rmdir /s /q .svelte-kit
+        ```
+        This directory contains cached build artifacts and will be regenerated.
+
+4.  **Run the Development Server:**
+    *   Attempt to start your development server:
+        If you use npm:
+        ```bash
+        npm run dev
+        ```
+        If you use yarn:
+        ```bash
+        yarn dev
+        ```
+
+5.  **Verify File Generation:**
+    *   If the server starts correctly, the error should be resolved. You can optionally verify that the directory `.svelte-kit/generated/server/` now contains `internal.js`.
+
+## If the Problem Persists
+
+If the error continues after following these steps meticulously:
+
+*   **Node.js or npm/yarn Version:** Ensure you are using a compatible Long-Term Support (LTS) version of Node.js. Check for any known issues with your `npm` or `yarn` versions.
+*   **Project Path:** While less common, if your project path contains unusual characters or is excessively long, try moving the project to a simpler path (e.g., `C:\dev\` or `~/dev/`) temporarily to rule this out.
+*   **External Factors:** Occasionally, antivirus software or other system-level file monitoring tools can interfere with `npm install` processes. Try temporarily disabling them if you suspect this.
+*   **Review Installation Logs:** If `npm install` or `yarn install` showed any warnings or errors, address those first.
+
+By following these steps, the integrity of your dependencies and SvelteKit's build cache should be restored, resolving the issue.
+
+## Ensure `src/app.html` Exists
+
+Another critical file for SvelteKit projects is `src/app.html`. This file serves as the main template for your application.
+
+**Symptom of Missing `app.html`:**
+You might see an error message like `src/app.html does not exist` in your build logs.
+
+**Solution:**
+Ensure you have a valid `frontend/src/app.html` file. A standard version looks like this:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>
+```
+
+If this file is missing, the SvelteKit build process will fail, which can lead to errors like the `__SERVER__/internal.js` not being found.

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>


### PR DESCRIPTION
This commit introduces the following changes:
1. Adds the standard `frontend/src/app.html` file, which was missing and causing build failures (leading to the `__SERVER__/internal.js` error).
2. Updates `frontend/TROUBLESHOOTING_GUIDE.md` to include information about the necessity of `src/app.html` for SvelteKit projects.

These changes should resolve the primary build error and provide better guidance for future troubleshooting.