### PR TITLE
Fix: Resolve ModuleNotFoundError for backend server

### DIFF
--- a/run_simulation.sh
+++ b/run_simulation.sh
@@ -5,7 +5,6 @@ set -e
 
 # Backend setup and launch
 echo "Starting backend setup..."
-cd backend
 
 # Check if venv exists, if not create it
 if [ ! -d "venv" ]; then
@@ -20,12 +19,9 @@ pip install fastapi uvicorn pydantic
 
 # Launch backend server
 echo "Launching backend server..."
-python -m uvicorn main:app --reload --port 8000 &
+python -m uvicorn backend.main:app --reload --port 8000 &
 echo "Backend server started in background. Attempting to access at http://localhost:8000"
 sleep 5
-
-# Navigate back to project root
-cd ..
 
 # --- NVM Setup ---
 echo "Setting up NVM and Node.js..."


### PR DESCRIPTION
The backend server was failing to start due to a ModuleNotFoundError when trying to import modules like `backend.simulations.base_simulation`. This occurred because Uvicorn was being launched from within the `backend` directory, leading to incorrect module path resolution.

This commit modifies `run_simulation.sh` to launch Uvicorn from your project's root directory using `python -m uvicorn backend.main:app`. This ensures that the Python interpreter can correctly locate the `backend` package and its submodules.

No changes were made to `backend/main.py` as the change in launch method is expected to resolve the import issues.