### PR TITLE
Fix: Correct simulation links and API calls

### DIFF
--- a/backend/simulations/biology/mendelian_genetics_module.py
+++ b/backend/simulations/biology/mendelian_genetics_module.py
@@ -20,7 +20,7 @@ class MendelianGeneticsModule(SimulationModule):
         return "Genética Mendeliana"
 
     def get_category(self) -> str:
-        return "Biologia"
+        return "Biology"
 
     def get_description(self) -> str:
         return "Simula cruzamentos genéticos Mendelianos e calcula proporções genotípicas e fenotípicas."

--- a/backend/simulations/chemistry/acid_base_module.py
+++ b/backend/simulations/chemistry/acid_base_module.py
@@ -15,7 +15,7 @@ class AcidBaseModule(SimulationModule):
         return "Reação Ácido-Base"
 
     def get_category(self) -> str:
-        return "Química"
+        return "Chemistry"
 
     def get_description(self) -> str:
         return "Simula a reação entre um ácido e uma base, calculando o pH final e a cor do indicador."

--- a/backend/simulations/physics/projectile_module.py
+++ b/backend/simulations/physics/projectile_module.py
@@ -16,7 +16,7 @@ class ProjectileModule(SimulationModule):
         return "Lançamento Oblíquo"
 
     def get_category(self) -> str:
-        return "Física"
+        return "Physics"
 
     def get_description(self) -> str:
         return "Analise a trajetória de um projétil em lançamento oblíquo."

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -64,9 +64,11 @@
               {:else}
                  <p class="image-placeholder">[Imagem Ilustrativa]</p>
               {/if}
-              <button style="background-color: #ADD8E6; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer;">
-                Iniciar Simulação
-              </button>
+              <a href={`/experiments/${exp.category.toLowerCase()}/${exp.id}`} style="text-decoration: none;">
+                <button style="background-color: #ADD8E6; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer; width: 100%;">
+                  Iniciar Simulação
+                </button>
+              </a>
             </div>
           {/each}
         </div>

--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -57,7 +57,7 @@
     console.log("Enviando para API Genética Mendeliana:", payload);
 
     try {
-      const response = await fetch('http://localhost:8000/api/simulation/biology/mendelian-genetics/start', {
+      const response = await fetch('http://localhost:8000/api/simulation/mendelian-genetics/start', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/routes/experiments/chemistry/acid-base/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base/+page.svelte
@@ -38,7 +38,7 @@
     console.log("Enviando para API:", payload); // Log para depuração
 
     try {
-      const response = await fetch('http://localhost:8000/api/simulation/chemistry/acid-base/start', {
+      const response = await fetch('http://localhost:8000/api/simulation/acid-base/start', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
+++ b/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
@@ -33,7 +33,7 @@
     console.log("Enviando para API Lançamento Oblíquo:", payload);
 
     try {
-      const response = await fetch('http://localhost:8000/api/simulation/physics/projectile-launch/start', {
+      const response = await fetch('http://localhost:8000/api/simulation/projectile-launch/start', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
This commit addresses two issues preventing simulations from working:

1.  Homepage navigation:
    - I modified `frontend/src/routes/+page.svelte` to correctly link "Iniciar Simulação" buttons to their respective simulation pages.
    - I updated backend simulation modules (`acid_base_module.py`, `projectile_module.py`, `mendelian_genetics_module.py`) to return English category names ("Chemistry", "Physics", "Biology") to align with frontend directory structure and link generation (e.g., `/experiments/chemistry/acid-base`).

2.  Simulation execution:
    - I modified Svelte components for individual simulation pages (`chemistry/acid-base/+page.svelte`, `physics/projectile-launch/+page.svelte`, `biology/mendelian-genetics/+page.svelte`) to use the correct `experiment_name` (the simple ID like "acid-base") in their API calls to the backend. This ensures the backend can find and execute the appropriate simulation module.

With these changes, you can now navigate from the homepage to each simulation, and the simulations are expected to run correctly.