### PR TITLE
Fix: Address issues in Genetics validation, Projectile SVG, and verif…

### DIFF
--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -23,14 +23,41 @@
   $: parent2GenotypeError = validateGenotypeInput(params.parent2_genotype);
 
   function validateGenotypeInput(genotype) {
-    if (!genotype) return "Genótipo não pode ser vazio.";
-    if (genotype.length !== 2) return "Genótipo deve ter 2 alelos (ex: AA, Aa, aa).";
-    // Validação de caracteres pode ser mais robusta se os alelos forem fixos
-    const allowedChars = (params.dominant_allele || 'A') + (params.recessive_allele || 'a');
+    // 1. Handle null or undefined genotype
+    if (genotype === null || genotype === undefined) {
+      return "Genótipo não pode ser vazio.";
+    }
+
+    // 2. Trim the genotype
+    const trimmedGenotype = genotype.trim();
+
+    // 3. Check if trimmedGenotype is empty
+    if (trimmedGenotype.length === 0) {
+      if (genotype.length > 0) {
+        return "Genótipo não pode ser composto apenas por espaços.";
+      } else {
+        return "Genótipo não pode ser vazio.";
+      }
+    }
+
+    // 4. Check if trimmedGenotype length is not 2
+    if (trimmedGenotype.length !== 2) {
+      return `Genótipo "${trimmedGenotype}" deve ter exatamente 2 alelos (ex: AA, Aa, aa). Por favor, insira duas letras.`;
+    }
+
+    // 5. Validate allowed characters using regex
+    const domAllele = params.dominant_allele || 'A';
+    const recAllele = params.recessive_allele || 'a';
+    // Ensure allowedChars uses the actual allele characters for the regex, case-insensitively
+    const allowedChars = `${domAllele}${recAllele}`;
+    // Regex to match exactly two characters, case-insensitive, from the allowed set
     const regex = new RegExp(`^[${allowedChars.toUpperCase()}${allowedChars.toLowerCase()}]{2}$`);
-    if (!regex.test(genotype)) {
-        // return `Genótipo contém alelos inválidos. Use apenas '${params.dominant_allele}' ou '${params.recessive_allele}'.`;
-    } // A validação principal de alelos é no backend.
+
+    if (!regex.test(trimmedGenotype)) {
+      return `Genótipo "${trimmedGenotype}" contém alelos inválidos. Use apenas '${domAllele}' e '${recAllele}'.`;
+    }
+
+    // 6. If all checks pass
     return "";
   }
 

--- a/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
+++ b/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
@@ -231,7 +231,7 @@
                   stroke="#aaa" stroke-width="1"/>
             <line x1="{svgAdjustedX(0, simulationResult.trajectory)}" y1="0"
                   x2="{svgAdjustedX(0, simulationResult.trajectory)}"
-                  y2="{svgAdjustedY(simulationResult.max_height, simulationResult.trajectory, simulationResult.max_height, simulationResult.parameters_used.initial_height) + 20}"  /* +20 para dar espaço */
+                  y2="{svgAdjustedY(simulationResult.max_height, simulationResult.trajectory, simulationResult.max_height, simulationResult.parameters_used.initial_height) + 20}"
                   stroke="#aaa" stroke-width="1"/>
 
             <!-- Trajetória -->


### PR DESCRIPTION
…y placeholder image

This commit resolves several issues based on your feedback:

1.  Mendelian Genetics Input Validation (`frontend/.../mendelian-genetics/+page.svelte`):
    - Enhanced the `validateGenotypeInput` function to trim whitespace from genotype inputs.
    - Added specific error messages for whitespace-only inputs.
    - Improved error message for incorrect genotype length.
    - Enabled and refined validation for allowed characters based on defined dominant/recessive alleles, providing you with feedback if invalid characters are used. This should resolve the problem where the UI seemed to always ask for two letters.

2.  Projectile Launch SVG Syntax Error (`frontend/.../projectile-launch/+page.svelte`):
    - Removed an invalid comment (`/* ... */`) found inside the `y2` attribute string of an SVG `<line>` element. This fixes the Vite pre-transform error and allows the page to render correctly.

3.  Missing `placeholder.png` Image:
    - Verified that the image `frontend/public/images/placeholder.png` exists.
    - Confirmed the default path in the backend (`/images/placeholder.png`) is correct.
    - The "Not Found" error you reported is likely transient or environment-specific, as the file and path are correct. No code changes were made for this specific item.