### PR TITLE
Fix: Correct further SVG error and refine genetics input validation

### DIFF
--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -126,7 +126,7 @@
       <fieldset>
         <legend>Progenitor 1</legend>
         <label for="parent1_genotype">Genótipo do Progenitor 1 (ex: AA, Aa, aa):</label>
-        <input type="text" id="parent1_genotype" bind:value={params.parent1_genotype} maxlength="2" pattern="[a-zA-Z]{2}" title="Digite 2 letras para o genótipo (ex: Aa)" required>
+        <input type="text" id="parent1_genotype" bind:value={params.parent1_genotype} maxlength="2" required>
         {#if parent1GenotypeError}
           <small class="input-error">{parent1GenotypeError}</small>
         {/if}
@@ -135,7 +135,7 @@
       <fieldset>
         <legend>Progenitor 2</legend>
         <label for="parent2_genotype">Genótipo do Progenitor 2 (ex: AA, Aa, aa):</label>
-        <input type="text" id="parent2_genotype" bind:value={params.parent2_genotype} maxlength="2" pattern="[a-zA-Z]{2}" title="Digite 2 letras para o genótipo (ex: Aa)" required>
+        <input type="text" id="parent2_genotype" bind:value={params.parent2_genotype} maxlength="2" required>
         {#if parent2GenotypeError}
           <small class="input-error">{parent2GenotypeError}</small>
         {/if}

--- a/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
+++ b/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
@@ -238,7 +238,7 @@
             <polyline
               points="{formatTrajectoryForSvg(simulationResult.trajectory, simulationResult.max_height, simulationResult.parameters_used.initial_height)}"
               fill="none"
-              stroke="#2980b9" /* Azul do plano de UI */
+              stroke="#2980b9"
               stroke-width="2"
             />
             <!-- Ponto inicial -->


### PR DESCRIPTION
This commit addresses follow-up issues based on your feedback:

1.  Projectile Launch SVG Syntax Error (`frontend/.../projectile-launch/+page.svelte`):
    - Removed another invalid comment (`/* ... */`) found inside the `stroke` attribute of the SVG `<polyline>` element. This resolves the remaining SVG-related rendering error on this page.

2.  Mendelian Genetics Input Validation (`frontend/.../mendelian-genetics/+page.svelte`):
    - Removed the `pattern` and `title` attributes from the genotype HTML input fields.
    - This change ensures that custom validation messages handled by the `validateGenotypeInput` JavaScript function are the primary source of feedback to you, rather than the browser's generic "Please match the requested format" message. This provides a more consistent and clearer validation experience. The `required` and `maxlength` attributes remain for basic constraints.