### PR TITLE
Fix: Remove misplaced HTML comment in SVG tag

### DIFF
--- a/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
+++ b/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
@@ -221,7 +221,7 @@
             width="100%"
             height="300"
             viewBox="{getSvgViewBox(simulationResult.trajectory, simulationResult.max_range, simulationResult.max_height, simulationResult.parameters_used.initial_height)}"
-            preserveAspectRatio="xMidYMin meet" <!-- Kept xMidYMin meet as implemented -->
+            preserveAspectRatio="xMidYMin meet"
             style="border: 1px solid #ccc; background-color: #f0f8ff;"
           >
             <!-- Eixos (simplificado) - Using version from Turn 40 prompt -->


### PR DESCRIPTION
The file frontend/src/routes/experiments/physics/projectile-launch/+page.svelte contained an HTML comment (`<!-- ... -->`) within the attribute list of an <svg> tag. This is invalid syntax and was causing a Svelte compilation error: "'<!--' is not a valid attribute name".

This commit removes the offending comment from the <svg> tag, resolving the compilation error. The `preserveAspectRatio` attribute remains as intended.