### PR TITLE
Fix: Ensure parameters_used is a dict in MendelianGenetics

### DIFF
--- a/backend/simulations/biology/mendelian_genetics_module.py
+++ b/backend/simulations/biology/mendelian_genetics_module.py
@@ -162,5 +162,5 @@ class MendelianGeneticsModule(SimulationModule):
             punnett_square=punnett_square_genotypes,
             offspring_genotypes=offspring_genotype_proportions,
             offspring_phenotypes=offspring_phenotype_proportions,
-            parameters_used=updated_params # Pass the potentially updated (stripped alleles) params
+            parameters_used=updated_params.model_dump() # Pass the potentially updated (stripped alleles) params
         )


### PR DESCRIPTION
The `parameters_used` field in the `MendelianCrossResult` is now explicitly converted to a dictionary using `model_dump()`. This prevents potential serialization issues when the FastAPI backend returns the simulation result, ensuring that the frontend receives a plain JSON object as expected.

This change addresses an issue where the Mendelian genetics experiment might fail to display results correctly even with valid input, potentially due to inconsistencies in how Pydantic model instances are handled versus dictionaries in the response pipeline.

Frontend validation for genotype and allele consistency was reviewed and confirmed to be functioning as intended, guiding you to correct mismatched inputs.