### PR TITLE
feat(physics): Implement unit conversion and adaptive trajectory

### DIFF
--- a/HANDOVER_DOCUMENT.md
+++ b/HANDOVER_DOCUMENT.md
@@ -148,5 +148,98 @@ Para executar e testar a aplicação:
     *   O uso de Pydantic para validação de parâmetros nos modelos é uma boa prática.
     *   A lógica de simulação está contida dentro do método `run_simulation`.
 
+## 4. Detalhes dos Módulos de Simulação Implementados
+
+Esta seção detalha aspectos específicos de módulos que receberam atualizações recentes significativas.
+
+### 4.1 Física: Lançamento Oblíquo (`projectile_module.py`)
+
+O módulo de lançamento oblíquo foi aprimorado com as seguintes funcionalidades:
+
+#### Novas Funcionalidades
+
+*   **Conversão de Unidades:**
+    *   **Descrição:** Permite que os usuários forneçam dados de entrada (velocidade inicial, altura inicial) em diferentes unidades e selecionem as unidades para os resultados da simulação.
+    *   **Impacto no Backend:**
+        *   `models_projectile.py`: Atualizado com novos campos para unidades de entrada (`initial_velocity_unit`, `initial_height_unit`) e um modelo `OutputUnitSelection` para especificar unidades de saída. Validadores foram adicionados para garantir que apenas unidades permitidas sejam usadas.
+        *   `unit_conversion.py`: Um novo arquivo foi criado contendo funções para converter valores entre unidades (e.g., m/s para km/h, ft para m) e a unidade base SI (m/s, m, s).
+        *   `projectile_module.py`: A lógica principal em `run_simulation` foi modificada para:
+            1.  Converter todos os parâmetros de entrada para unidades SI (metros, segundos, m/s) usando as funções de `unit_conversion.py`.
+            2.  Realizar todos os cálculos de física interna exclusivamente com unidades SI.
+            3.  Converter os resultados finais (alcance, altura máxima, tempo de voo, componentes da velocidade, pontos da trajetória) para as unidades de saída selecionadas pelo usuário antes de retornar a resposta.
+    *   **Requisitos para Frontend:**
+        *   A UI deve permitir que os usuários selecionem a unidade para os campos de entrada relevantes (velocidade inicial, altura inicial).
+        *   A UI deve permitir que os usuários selecionem as unidades desejadas para os principais resultados numéricos.
+        *   As chamadas de API para `/api/simulation/projectile-launch/start` devem incluir os novos campos de unidade no payload.
+        *   Os resultados exibidos na UI devem indicar claramente as unidades correspondentes.
+
+*   **Geração Adaptativa de Pontos de Trajetória:**
+    *   **Descrição:** O método de geração de pontos para a trajetória do projétil agora usa um passo de tempo (`time_step`) adaptativo.
+    *   **Impacto no Backend (`projectile_module.py`):**
+        *   Se o tempo total de voo for muito curto, o `time_step` é reduzido para garantir um número mínimo de pontos (atualmente 20 intervalos, resultando em 21 pontos) para uma plotagem suave.
+        *   Se o tempo total de voo for muito longo (resultando em mais de 2000 pontos com o `time_step` padrão de 0.05s), o `time_step` é aumentado para limitar o número total de pontos (atualmente 2000 intervalos, resultando em 2001 pontos), otimizando a performance.
+        *   Para durações de voo intermediárias, o `time_step` padrão de 0.05s é mantido.
+    *   **Impacto no Frontend:**
+        *   A plotagem da trajetória deve se beneficiar dessa mudança, mostrando curvas mais suaves para lançamentos de baixa energia e evitando sobrecarga de dados para lançamentos de alta energia. Nenhuma alteração direta na lógica de plotagem do frontend é esperada, além de lidar com o número variável de pontos.
+
+#### Testes Específicos do Módulo
+
+*   Os testes unitários em `backend/simulations/physics/test_projectile_module.py` foram significativamente expandidos para cobrir:
+    *   Casos de teste com diferentes unidades de entrada (e.g., velocidade em km/h, altura em ft) e verificação dos resultados em SI.
+    *   Casos de teste para conversão de unidades de saída (e.g., solicitar resultados em km, ft, min).
+    *   Testes específicos para a lógica de geração adaptativa da trajetória, verificando o número de pontos gerados para cenários de baixa energia, alta energia (limitado) e casos padrão.
+    *   Os testes existentes foram atualizados para incluir os novos parâmetros de unidade.
+
+## 5. Pontos de Atenção e Próximas Implementações (Renumerado)
+
+*   **Criptografia de Simulações Salvas (RNF2.4):**
+    *   Os dados em `backend/saved_simulations/` são atualmente armazenados em JSON puro.
+    *   Implementar criptografia (ex: usando a biblioteca `cryptography`) para proteger esses dados. Isso envolverá a modificação dos endpoints de salvar e carregar para criptografar/descriptografar os dados. Gerenciamento seguro de chaves será essencial.
+
+*   **Desenvolvimento do Frontend:**
+    *   A API backend está pronta para ser consumida. O próximo grande passo é desenvolver a interface do usuário (frontend React/Svelte conforme planejado) que interaja com esta API.
+
+*   **Novos Experimentos:**
+    *   Adicionar mais simulações seguindo o padrão `SimulationModule`:
+        1.  Crie uma nova subpasta em `backend/simulations/<categoria>/`.
+        2.  Defina `models_<experimento>.py` com os modelos Pydantic para parâmetros e resultados.
+        3.  Implemente `<experimento>_module.py` herdando de `SimulationModule`.
+        4.  Adicione testes unitários em `test_<experimento>_module.py`.
+        *   O novo experimento será descoberto automaticamente pela API.
+
+*   **Tratamento de Erros e Logging:**
+    *   Expandir o tratamento de erros na API.
+    *   Implementar logging estruturado para monitoramento e depuração.
+
+*   **Persistência de Dados Avançada:**
+    *   Para um cenário de produção ou com muitos usuários, substituir o armazenamento de simulações em arquivos JSON por um banco de dados (SQL ou NoSQL) pode ser necessário para melhor desempenho, concorrência e gerenciamento.
+
+*   **Segurança da API:**
+    *   Se a API for exposta publicamente ou usada em um ambiente multiusuário, implementar mecanismos de autenticação e autorização (ex: OAuth2 com tokens JWT) será crucial.
+
+*   **Refinamento do `run_simulation.sh`:**
+    *   O script `run_simulation.sh` atualmente foca em iniciar o ambiente de desenvolvimento. Pode ser estendido para:
+        *   Executar todos os testes unitários.
+        *   Executar simulações específicas via linha de comando, imprimindo os resultados (útil para depuração rápida).
+
+*   **Documentação da API:**
+    *   Embora o FastAPI forneça documentação automática via Swagger UI (`/docs`) e ReDoc (`/redoc`), manter um documento de API separado (como o `Documento de API` original do projeto) atualizado com detalhes e exemplos pode ser útil.
+
+## 6. Revisão dos Arquivos Chave (Conceitual) (Renumerado)
+
+*   **`backend/main.py`:**
+    *   A lógica de roteamento foi significativamente simplificada com o endpoint de simulação genérico.
+    *   A descoberta de módulos na inicialização é eficiente.
+    *   Os endpoints de salvar/carregar usam manipulação de arquivos JSON; a transição para um banco de dados ou adição de criptografia afetará principalmente esta parte.
+    *   O tratamento de erros para validação de payload e operações de arquivo parece adequado para o estágio atual.
+
+*   **`backend/simulations/base_simulation.py`:**
+    *   A interface `SimulationModule` e os modelos base `BaseSimulationParams`, `BaseSimulationResult` fornecem uma boa espinha dorsal para a padronização e extensibilidade dos módulos de simulação.
+
+*   **Módulos de Simulação (ex: `acid_base_module.py`, `models_acid_base.py`):**
+    *   A separação da lógica do módulo e seus modelos Pydantic está clara.
+    *   O uso de Pydantic para validação de parâmetros nos modelos é uma boa prática.
+    *   A lógica de simulação está contida dentro do método `run_simulation`.
+
 Este documento deve servir como um bom ponto de partida para a continuação do desenvolvimento do Simulador de Experimentos Educativos.
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ Atualmente, as seguintes simulações estão implementadas:
 
 2.  **Física: Lançamento Oblíquo**
     *   Defina a velocidade inicial, ângulo de lançamento, altura inicial (opcional) e gravidade (opcional) de um projétil.
-    *   Visualize a trajetória, alcance máximo, altura máxima e tempo total de voo.
+    *   **Unidades de Entrada:**
+        *   Velocidade Inicial: Pode ser fornecida em "m/s" (padrão), "km/h", "ft/s", ou "mph".
+        *   Altura Inicial: Pode ser fornecida em "m" (padrão) ou "ft".
+        *   Gravidade: Assume-se que está em m/s² para cálculos internos.
+    *   **Unidades de Saída:** Os resultados da simulação (velocidade inicial x/y, tempo total, alcance máximo, altura máxima) podem ser exibidos nas seguintes unidades, conforme selecionado pelo usuário (padrão para m/s, s, m, m):
+        *   Velocidade: "m/s", "km/h", "ft/s", "mph"
+        *   Tempo: "s", "min"
+        *   Distância (alcance/altura): "m", "km", "ft", "mi"
+    *   **Geração de Trajetória:** A geração de pontos da trajetória é adaptativa para garantir uma visualização suave para lançamentos curtos e para evitar um número excessivo de pontos para lançamentos longos.
+    *   Visualize a trajetória, alcance máximo, altura máxima e tempo total de voo, com unidades selecionadas.
     *   Acesse em: `http://localhost:5173/experiments/physics/projectile-launch`
 
 3.  **Biologia: Genética Mendeliana (Cruzamento Monoíbrido)**

--- a/backend/simulations/physics/models_projectile.py
+++ b/backend/simulations/physics/models_projectile.py
@@ -1,37 +1,120 @@
-from typing import List, Optional, Any, Dict
-from pydantic import BaseModel, Field
+from typing import List, Optional, Literal
+from pydantic import BaseModel, Field, field_validator
 from backend.simulations.base_simulation import BaseSimulationParams, BaseSimulationResult
 
+# Allowed Unit Literals
+ALLOWED_VELOCITY_UNITS = Literal["m/s", "km/h", "ft/s", "mph"]
+ALLOWED_LENGTH_UNITS = Literal["m", "ft"]
+ALLOWED_OUTPUT_TIME_UNITS = Literal["s", "min"]
+ALLOWED_OUTPUT_LENGTH_UNITS = Literal["m", "km", "ft", "mi"]
+
+class OutputUnitSelection(BaseModel):
+    velocity_unit: Optional[ALLOWED_VELOCITY_UNITS] = Field(
+        "m/s",
+        description="Unidade para velocidades nos resultados (e.g., componentes da velocidade inicial)."
+    )
+    time_unit: Optional[ALLOWED_OUTPUT_TIME_UNITS] = Field(
+        "s",
+        description="Unidade para o tempo total de voo."
+    )
+    range_unit: Optional[ALLOWED_OUTPUT_LENGTH_UNITS] = Field(
+        "m",
+        description="Unidade para o alcance máximo."
+    )
+    height_unit: Optional[ALLOWED_OUTPUT_LENGTH_UNITS] = Field(
+        "m",
+        description="Unidade para a altura máxima."
+    )
+
+    @field_validator('velocity_unit')
+    @classmethod
+    def validate_velocity_unit(cls, value):
+        if value not in cls.model_fields['velocity_unit'].annotation.__args__[0].__args__: # Accessing Literal values
+            raise ValueError(f"Unidade de velocidade inválida: {value}. Permitidas: {cls.model_fields['velocity_unit'].annotation.__args__[0].__args__}")
+        return value
+
+    @field_validator('time_unit')
+    @classmethod
+    def validate_time_unit(cls, value):
+        if value not in cls.model_fields['time_unit'].annotation.__args__[0].__args__:
+            raise ValueError(f"Unidade de tempo inválida: {value}. Permitidas: {cls.model_fields['time_unit'].annotation.__args__[0].__args__}")
+        return value
+
+    @field_validator('range_unit')
+    @classmethod
+    def validate_range_unit(cls, value):
+        if value not in cls.model_fields['range_unit'].annotation.__args__[0].__args__:
+            raise ValueError(f"Unidade de alcance inválida: {value}. Permitidas: {cls.model_fields['range_unit'].annotation.__args__[0].__args__}")
+        return value
+
+    @field_validator('height_unit')
+    @classmethod
+    def validate_height_unit(cls, value):
+        if value not in cls.model_fields['height_unit'].annotation.__args__[0].__args__:
+            raise ValueError(f"Unidade de altura inválida: {value}. Permitidas: {cls.model_fields['height_unit'].annotation.__args__[0].__args__}")
+        return value
+
+
 class ProjectileLaunchParams(BaseSimulationParams):
-    initial_velocity: float = Field(..., gt=0, description="Velocidade inicial do projétil (m/s)")
-    launch_angle: float = Field(..., ge=0, lt=90, description="Ângulo de lançamento em graus (0-90, não inclusivo de 90 para oblíquo)")
-    initial_height: Optional[float] = Field(0.0, ge=0, description="Altura inicial do lançamento (m)")
-    gravity: Optional[float] = Field(9.81, gt=0, description="Aceleração devido à gravidade (m/s^2)")
+    initial_velocity: float = Field(..., gt=0, description="Valor da velocidade inicial do projétil.")
+    initial_velocity_unit: Optional[ALLOWED_VELOCITY_UNITS] = Field(
+        "m/s",
+        description="Unidade da velocidade inicial."
+    )
+    launch_angle: float = Field(..., ge=0, lt=90, description="Ângulo de lançamento em graus (0° é horizontal, <90°).")
+    initial_height: Optional[float] = Field(0.0, ge=0, description="Valor da altura inicial do lançamento.")
+    initial_height_unit: Optional[ALLOWED_LENGTH_UNITS] = Field(
+        "m",
+        description="Unidade da altura inicial."
+    )
+    gravity: Optional[float] = Field(9.81, gt=0, description="Aceleração devido à gravidade. Assume-se m/s^2 e é usada como tal internamente. A conversão de outras unidades de entrada não é diretamente suportada para este campo.")
+    output_units: Optional[OutputUnitSelection] = Field(
+        default_factory=OutputUnitSelection,
+        description="Preferências de unidade para os resultados da simulação."
+    )
+
+    @field_validator('initial_velocity_unit')
+    @classmethod
+    def validate_initial_velocity_unit(cls, value):
+        if value not in cls.model_fields['initial_velocity_unit'].annotation.__args__[0].__args__:
+             raise ValueError(f"Unidade de velocidade inicial inválida: {value}. Permitidas: {cls.model_fields['initial_velocity_unit'].annotation.__args__[0].__args__}")
+        return value
+
+    @field_validator('initial_height_unit')
+    @classmethod
+    def validate_initial_height_unit(cls, value):
+        if value not in cls.model_fields['initial_height_unit'].annotation.__args__[0].__args__:
+            raise ValueError(f"Unidade de altura inicial inválida: {value}. Permitidas: {cls.model_fields['initial_height_unit'].annotation.__args__[0].__args__}")
+        return value
 
 class TrajectoryPoint(BaseModel):
-    time: float = Field(..., description="Tempo em segundos")
-    x: float = Field(..., description="Posição horizontal (x) em metros")
-    y: float = Field(..., description="Posição vertical (y) em metros")
+    time: float = Field(..., description="Tempo em segundos (sempre em 's' nesta lista de trajetória).")
+    x: float = Field(..., description="Posição horizontal (x). A unidade corresponderá a ProjectileLaunchResult.max_range_unit.")
+    y: float = Field(..., description="Posição vertical (y). A unidade corresponderá a ProjectileLaunchResult.max_height_unit.")
 
 class ProjectileLaunchResult(BaseSimulationResult):
-    initial_velocity_x: float = Field(..., description="Componente X da velocidade inicial (m/s)")
-    initial_velocity_y: float = Field(..., description="Componente Y da velocidade inicial (m/s)")
-    total_time: float = Field(..., description="Tempo total de voo (s)")
-    max_range: float = Field(..., description="Alcance horizontal máximo (m)")
-    max_height: float = Field(..., description="Altura máxima atingida (m)")
-    trajectory: List[TrajectoryPoint] = Field(..., description="Lista de pontos da trajetória")
-    parameters_used: ProjectileLaunchParams # type: ignore[assignment]
-    # Pydantic V2 handles model assignment to Dict[str, Any] in the base class.
-    # parameters_used: Dict[str, Any] # This would also be valid as per BaseSimulationResult
+    initial_velocity_x: float = Field(..., description="Componente X da velocidade inicial.")
+    initial_velocity_x_unit: str = Field(..., description="Unidade da componente X da velocidade inicial.")
+    initial_velocity_y: float = Field(..., description="Componente Y da velocidade inicial.")
+    initial_velocity_y_unit: str = Field(..., description="Unidade da componente Y da velocidade inicial.")
+
+    total_time: float = Field(..., description="Tempo total de voo.")
+    total_time_unit: str = Field(..., description="Unidade do tempo total de voo.")
+
+    max_range: float = Field(..., description="Alcance horizontal máximo.")
+    max_range_unit: str = Field(..., description="Unidade do alcance horizontal máximo.")
+
+    max_height: float = Field(..., description="Altura máxima atingida (relativa ao ponto y=0).")
+    max_height_unit: str = Field(..., description="Unidade da altura máxima.")
+
+    trajectory: List[TrajectoryPoint] = Field(..., description="Lista de pontos da trajetória. 'time' é sempre em segundos. 'x' e 'y' terão unidades correspondentes a 'max_range_unit' e 'max_height_unit' respectivamente.")
+
+    parameters_used: ProjectileLaunchParams
+    # A anotação 'type: ignore[assignment]' foi removida pois o Pydantic v2 geralmente lida bem
+    # com a atribuição de um modelo Pydantic onde um Dict[str, Any] é esperado na classe base,
+    # especialmente durante a serialização. Se problemas surgirem, pode ser reavaliado.
 
     class Config:
-        # Ensure that Pydantic can handle the ProjectileLaunchParams type for parameters_used
-        # when converting to dict for the BaseSimulationResult if necessary.
-        # This is generally handled well in Pydantic V2 by default.
-        # For older Pydantic or stricter typing, a model_validator or serializer might be used
-        # in BaseSimulationResult, or ensure parameters_used is always a dict.
-        # However, the current setup where BaseSimulationResult expects Dict[str, Any]
-        # and we assign a Pydantic model instance to parameters_used in the child class
-        # typically works because Pydantic model instances are dict-like and can be
-        # serialized to dictionaries (e.g. via model_dump()).
+        # Pydantic V2 não requer mais `orm_mode = True`. `from_attributes = True` é o substituto se necessário para ORM.
+        # Para este caso, a configuração padrão deve ser suficiente.
         pass

--- a/backend/simulations/physics/projectile_module.py
+++ b/backend/simulations/physics/projectile_module.py
@@ -1,11 +1,15 @@
 import math
-from typing import List, Optional, Type, Any, Dict
-
-from fastapi import HTTPException # For input validation if kept in module
-from pydantic import BaseModel # BaseModel is used by Type[BaseModel]
-
-from backend.simulations.base_simulation import SimulationModule, BaseSimulationParams # BaseSimulationParams not strictly needed here but good for context
-from .models_projectile import ProjectileLaunchParams, TrajectoryPoint, ProjectileLaunchResult
+from typing import List, Optional, Type # Removed Any, Dict as they are not explicitly used after changes
+# BaseModel is not directly used, Type is sufficient for parameter_schema
+from backend.simulations.base_simulation import SimulationModule # BaseSimulationParams not strictly needed here
+from .models_projectile import ProjectileLaunchParams, TrajectoryPoint, ProjectileLaunchResult, OutputUnitSelection
+from .unit_conversion import (
+    convert_velocity_to_base,
+    convert_length_to_base,
+    convert_velocity_from_base,
+    convert_length_from_base,
+    convert_time_from_base
+)
 
 class ProjectileModule(SimulationModule):
 
@@ -47,83 +51,140 @@ class ProjectileModule(SimulationModule):
         # The problem description mentions "Lançamento Oblíquo", so `gt=0` might be more appropriate for launch_angle if strictly oblique.
         # The model has `ge=0` allowing horizontal launch. We'll stick to model validation.
 
-        g = params.gravity
-        v0 = params.initial_velocity
+        # Input conversion to SI units
+        # Gravity is assumed to be in m/s^2 as per model description.
+        g_si = params.gravity if params.gravity is not None else 9.81 # Default if not provided
+
+        v0_si = convert_velocity_to_base(params.initial_velocity, params.initial_velocity_unit or "m/s")
+        y0_si = convert_length_to_base(params.initial_height if params.initial_height is not None else 0.0, params.initial_height_unit or "m")
+
         angle_rad = math.radians(params.launch_angle)
-        y0 = params.initial_height
 
-        v0x = v0 * math.cos(angle_rad)
-        v0y = v0 * math.sin(angle_rad)
+        v0x_si = v0_si * math.cos(angle_rad)
+        v0y_si = v0_si * math.sin(angle_rad)
 
-        max_h_from_y0 = (v0y**2) / (2 * g) if v0y > 0 else 0
-        max_h = y0 + max_h_from_y0
+        # Calculations in SI units
+        max_h_from_y0_si = (v0y_si**2) / (2 * g_si) if v0y_si > 0 else 0
+        max_h_si = y0_si + max_h_from_y0_si
 
-        # discriminant = b^2 - 4ac where a = -g/2, b = v0y, c = y0 (for y(t) = y0 + v0y*t - 0.5*g*t^2 = 0)
-        # Or, for 0.5*g*t^2 - v0y*t - y0 = 0, a = 0.5g, b = -v0y, c = -y0
-        discriminant_calc = (v0y**2) + (2 * g * y0) # Simplified from (-v0y)^2 - 4*(0.5g)*(-y0) = v0y^2 + 2*g*y0
+        discriminant_calc_si = (v0y_si**2) + (2 * g_si * y0_si)
 
-        if discriminant_calc < 0: # Should not happen if y0 >= 0 and g > 0
-            total_t = 0
+        if discriminant_calc_si < -1e-9: # Added tolerance for floating point issues
+            total_t_si = 0.0
         else:
-            # t = (v0y + sqrt(v0y^2 + 2gy0)) / g  (time to reach y=0 from y0, taking positive root for future time)
-            # This formula is for when the object hits the ground (y=0).
-            # If v0y is negative (launched downwards) or zero, it hits ground.
-            # If v0y is positive (launched upwards), it goes up, then comes down.
-            if y0 == 0 and v0y == 0: # Starts on ground, no vertical velocity (e.g. angle=0, y0=0)
-                 total_t = 0
-            elif y0 == 0: # Starts on ground with some vertical velocity (angle > 0, y0=0)
-                 total_t = (2 * v0y) / g
-            else: # Starts at y0 > 0
-                 total_t = (v0y + math.sqrt(discriminant_calc)) / g
+            if discriminant_calc_si < 0: discriminant_calc_si = 0 # Clamp if very slightly negative due to precision
 
-        if total_t < 0: # Should not occur with proper physics unless initial conditions are unusual
-            total_t = 0
+            if y0_si == 0 and abs(v0y_si) < 1e-9: # Starts on ground, no vertical velocity
+                 total_t_si = 0.0
+            elif y0_si == 0: # Starts on ground with some vertical velocity
+                 total_t_si = (2 * v0y_si) / g_si
+            else: # Starts at y0_si > 0
+                 total_t_si = (v0y_si + math.sqrt(discriminant_calc_si)) / g_si
 
-        max_r = v0x * total_t
+        if total_t_si < 0: total_t_si = 0.0 # Ensure non-negative time
 
-        trajectory_points: List[TrajectoryPoint] = []
-        time_step = 0.05
-        current_time = 0.0
+        max_r_si = v0x_si * total_t_si
 
-        if total_t > 1e-6: # Only generate trajectory if there's flight time
-            while current_time <= total_t + 1e-9: # Add small epsilon to ensure last point is included
-                x = v0x * current_time
-                y = y0 + v0y * current_time - 0.5 * g * current_time**2
+        trajectory_points_si: List[TrajectoryPoint] = []
+        time_step_si = 0.05 # Default time_step for SI calculations
+        current_time_si = 0.0
 
-                if y < 0: y = 0 # Object cannot go below ground
+        min_desired_points = 20
+        max_points_limit = 2000
 
-                trajectory_points.append(TrajectoryPoint(time=round(current_time,3), x=round(x,3), y=round(y,3)))
+        if total_t_si > 1e-5: # Effectively non-zero flight time
+            if (total_t_si / time_step_si) < min_desired_points:
+                time_step_si = total_t_si / min_desired_points
 
-                if y == 0 and current_time > 1e-6 and current_time < total_t - 1e-9 : # Stop if hits ground before total_t (e.g. due to rounding in time_step)
-                    # This check might be redundant if total_t is calculated accurately as time to hit ground.
-                    pass # Loop continues till total_t
+            if (total_t_si / time_step_si) > max_points_limit:
+                time_step_si = total_t_si / max_points_limit
+        # The case for total_t_si <= 1e-6 (effectively zero flight time) is handled later by appending one point.
+        # No special 'elif' needed here for adaptive time step, as it's guarded by total_t_si > 1e-5.
 
-                if current_time > total_t: # Ensure we don't overshoot total_t significantly
+        if total_t_si > 1e-6: # Generate trajectory if there's significant flight time
+            while current_time_si <= total_t_si + 1e-9: # Add epsilon for last point
+                x_si = v0x_si * current_time_si
+                y_si = y0_si + v0y_si * current_time_si - 0.5 * g_si * current_time_si**2
+
+                if y_si < 0: y_si = 0.0 # Object cannot go below ground
+
+                # Store SI points temporarily
+                trajectory_points_si.append(TrajectoryPoint(time=current_time_si, x=x_si, y=y_si))
+
+                if y_si == 0.0 and current_time_si > 1e-6 and abs(current_time_si - total_t_si) > 1e-9 :
+                    # If it hits ground before calculated total_t_si (e.g. due to time step choice)
+                    # and it's not already the last point, break early.
+                    # This ensures trajectory stops when it hits ground.
+                    total_t_si = current_time_si # Adjust total_t_si to actual impact time
                     break
-                current_time += time_step
-                # Ensure the loop terminates, especially if total_t is very small or time_step is tiny
-                if len(trajectory_points) > 2000: # Safety break for very long simulations
+
+                if current_time_si > total_t_si and abs(current_time_si - total_t_si) > 1e-9 :
                     break
 
-            # Ensure final point at total_t and y=0 is included if not already captured
-            if not trajectory_points or abs(trajectory_points[-1].time - total_t) > 1e-4 :
-                x_final = v0x * total_t
-                trajectory_points.append(TrajectoryPoint(time=round(total_t,3), x=round(x_final,3), y=0.0))
-            elif trajectory_points[-1].y != 0.0 and abs(trajectory_points[-1].time - total_t) < 1e-4:
-                 trajectory_points[-1].y = 0.0 # Correct y for the last point if it's at total_t
+                current_time_si += time_step_si
+                if time_step_si < 1e-9 : # Avoid infinite loop if time_step becomes zero
+                    if len(trajectory_points_si) >= min_desired_points: break
+                    else: break # Pathological case
 
-        else: # No flight time (e.g. on the ground with no upward velocity)
-            trajectory_points.append(TrajectoryPoint(time=0.0, x=0.0, y=y0))
-            if y0 == 0 and v0 == 0:
-                max_h = 0.0
+                if len(trajectory_points_si) > max_points_limit + 10: # Safety break
+                    break
+
+            # Ensure final point at total_t_si (and y_si=0 if applicable) is captured
+            if not trajectory_points_si or abs(trajectory_points_si[-1].time - total_t_si) > 1e-4 :
+                x_final_si = v0x_si * total_t_si
+                y_final_si = y0_si + v0y_si * total_t_si - 0.5 * g_si * total_t_si**2
+                if y_final_si < 0 : y_final_si = 0.0
+                trajectory_points_si.append(TrajectoryPoint(time=total_t_si, x=x_final_si, y=y_final_si))
+            elif trajectory_points_si: # If list is not empty
+                 # Correct y for the last point if it should be at ground
+                 last_point = trajectory_points_si[-1]
+                 if abs(last_point.time - total_t_si) < 1e-4 and last_point.y != 0.0 and y0_si + v0y_si * total_t_si - 0.5 * g_si * total_t_si**2 < 1e-3 :
+                     trajectory_points_si[-1].y = 0.0
+
+
+        else: # No significant flight time or zero flight time
+            # Append a single point representing the initial state (in SI units for now)
+            trajectory_points_si.append(TrajectoryPoint(time=0.0, x=0.0, y=y0_si))
+            if y0_si == 0.0 and abs(v0_si) < 1e-9 : # if started on ground with no velocity
+                max_h_si = 0.0 # Max height is initial height
+
+        # Output Conversion
+        output_units = params.output_units if params.output_units is not None else OutputUnitSelection()
+
+        final_v0x = convert_velocity_from_base(v0x_si, output_units.velocity_unit or "m/s")
+        final_v0y = convert_velocity_from_base(v0y_si, output_units.velocity_unit or "m/s")
+        final_total_t = convert_time_from_base(total_t_si, output_units.time_unit or "s")
+        final_max_r = convert_length_from_base(max_r_si, output_units.range_unit or "m")
+        final_max_h = convert_length_from_base(max_h_si, output_units.height_unit or "m")
+
+        final_trajectory_points: List[TrajectoryPoint] = []
+        for point_si in trajectory_points_si:
+            # Time is always in seconds for trajectory points as per model spec
+            time_val = round(point_si.time, 3)
+            x_val = round(convert_length_from_base(point_si.x, output_units.range_unit or "m"), 3)
+            y_val = round(convert_length_from_base(point_si.y, output_units.height_unit or "m"), 3)
+            final_trajectory_points.append(TrajectoryPoint(time=time_val, x=x_val, y=y_val))
+
+        # Ensure at least one point in final trajectory if total_t_si was ~0
+        if not final_trajectory_points:
+             x_val = round(convert_length_from_base(0.0, output_units.range_unit or "m"),3)
+             y_val = round(convert_length_from_base(y0_si, output_units.height_unit or "m"),3)
+             final_trajectory_points.append(TrajectoryPoint(time=0.0, x=x_val, y=y_val))
 
 
         return ProjectileLaunchResult(
-            initial_velocity_x=round(v0x, 3),
-            initial_velocity_y=round(v0y, 3),
-            total_time=round(total_t, 3),
-            max_range=round(max_r, 3),
-            max_height=round(max_h, 3),
-            trajectory=trajectory_points,
-            parameters_used=params # Assign the input params directly
+            initial_velocity_x=round(final_v0x, 3),
+            initial_velocity_y=round(final_v0y, 3),
+            total_time=round(final_total_t, 3),
+            max_range=round(final_max_r, 3),
+            max_height=round(final_max_h, 3),
+            trajectory=final_trajectory_points,
+
+            initial_velocity_x_unit=output_units.velocity_unit or "m/s",
+            initial_velocity_y_unit=output_units.velocity_unit or "m/s",
+            total_time_unit=output_units.time_unit or "s",
+            max_range_unit=output_units.range_unit or "m",
+            max_height_unit=output_units.height_unit or "m",
+
+            parameters_used=params
         )

--- a/backend/simulations/physics/test_projectile_module.py
+++ b/backend/simulations/physics/test_projectile_module.py
@@ -1,204 +1,388 @@
 import pytest
 import math
-# from fastapi import HTTPException # Not testing direct HTTPException from module if Pydantic handles validation.
-# from pydantic import ValidationError # Using ValueError for Pydantic v2 default validation errors.
 
 from backend.simulations.physics.projectile_module import ProjectileModule
-from backend.simulations.physics.models_projectile import ProjectileLaunchParams, TrajectoryPoint
+from backend.simulations.physics.models_projectile import ProjectileLaunchParams, TrajectoryPoint, OutputUnitSelection
+from backend.simulations.physics import unit_conversion as uc
 
 # Instantiate the module once for all tests
 module = ProjectileModule()
 
+# Default output units (SI) for many tests
+SI_OUTPUT_UNITS = OutputUnitSelection(
+    velocity_unit="m/s",
+    time_unit="s",
+    range_unit="m",
+    height_unit="m"
+)
+
 # Test 1: Lançamento a 45 graus (alcance máximo em solo plano)
 def test_launch_45_degrees():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=45, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
 
     # Theoretical calculations for g=9.81, v0=10, angle=45, h0=0:
     # Max Height (H) = (v0^2 * sin^2(angle)) / (2 * g) = (100 * 0.5) / (2 * 9.81) = 2.5484 m
-    # Total Time (T) = (2 * v0 * sin(angle)) / g = (2 * 10 * sqrt(2)/2) / 9.81 = 1.4416 s
+    # Total Time (T) = (2 * v0 * sin(angle)) / g = (2 * 10 * math.sqrt(2)/2) / 9.81 = 1.4416 s
     # Max Range (R)  = (v0^2 * sin(2*angle)) / g = (100 * 1) / 9.81 = 10.1936 m
 
-    assert math.isclose(result.max_range, 10.1936, rel_tol=1e-3), f"Max range expected ~10.1936, got {result.max_range}"
-    assert math.isclose(result.max_height, 2.5484, rel_tol=1e-3), f"Max height expected ~2.5484, got {result.max_height}"
-    assert math.isclose(result.total_time, 1.4416, rel_tol=1e-3), f"Total time expected ~1.4416, got {result.total_time}"
+    assert math.isclose(result.max_range, 10.1936, rel_tol=1e-3)
+    assert math.isclose(result.max_height, 2.5484, rel_tol=1e-3)
+    assert math.isclose(result.total_time, 1.4416, rel_tol=1e-3)
 
-    assert result.trajectory is not None, "Trajectory should not be None"
-    assert len(result.trajectory) > 0, "Trajectory should not be empty"
+    assert result.initial_velocity_x_unit == "m/s"
+    assert result.initial_velocity_y_unit == "m/s"
+    assert result.total_time_unit == "s"
+    assert result.max_range_unit == "m"
+    assert result.max_height_unit == "m"
 
-    assert math.isclose(result.trajectory[0].x, 0.0, abs_tol=1e-3), "Initial x should be 0"
-    assert math.isclose(result.trajectory[0].y, 0.0, abs_tol=1e-3), "Initial y should be 0"
-
-    assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2), f"Final y should be close to 0, got {result.trajectory[-1].y}"
-    assert math.isclose(result.trajectory[-1].x, result.max_range, rel_tol=1e-2), f"Final x should be close to max_range, got {result.trajectory[-1].x}"
-
-    assert result.parameters_used == params, "parameters_used should match input params"
-
+    assert result.trajectory is not None
+    assert len(result.trajectory) > 0
+    assert math.isclose(result.trajectory[0].x, 0.0, abs_tol=1e-3)
+    assert math.isclose(result.trajectory[0].y, 0.0, abs_tol=1e-3)
+    assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
+    assert math.isclose(result.trajectory[-1].x, result.max_range, rel_tol=1e-2)
+    assert result.parameters_used == params
 
 # Test 2: Lançamento com ângulo alto (ex: 80 graus)
 def test_launch_high_angle():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=80, initial_height=0, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=80, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    # H = (100 * sin^2(80)) / (2 * 9.81) approx 4.943 m
-    # T = (2 * 10 * sin(80)) / 9.81 approx 2.0077 s
-    # R = (100 * sin(160)) / 9.81 approx 3.486 m
 
     assert math.isclose(result.max_range, 3.486, rel_tol=1e-3)
     assert math.isclose(result.max_height, 4.943, rel_tol=1e-3)
     assert math.isclose(result.total_time, 2.0077, rel_tol=1e-3)
-
+    assert result.max_range_unit == "m"
     assert result.trajectory is not None and len(result.trajectory) > 0
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
     assert result.parameters_used == params
 
 # Test 3: Lançamento horizontal de uma altura
 def test_launch_horizontal_from_height():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=0, initial_height=10, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=0, initial_height=10, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
 
-    # Max height = initial_height = 10m.
-    # Time to fall: t = sqrt(2*y0/g) = sqrt(2*10/9.81) approx 1.4278 s
-    # Max range = v0x * t = 10 * 1.4278 = 14.278 m
-
     assert math.isclose(result.max_range, 14.278, rel_tol=1e-3)
-    assert math.isclose(result.max_height, 10.0, rel_tol=1e-3)
+    assert math.isclose(result.max_height, 10.0, rel_tol=1e-3) # Max height is initial height
     assert math.isclose(result.total_time, 1.4278, rel_tol=1e-3)
-
+    assert result.max_range_unit == "m"
+    assert result.max_height_unit == "m" # Relative to y=0, so it's initial height
     assert result.trajectory is not None and len(result.trajectory) > 0
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
     assert result.parameters_used == params
 
-# Test 4: Validação de entrada (Pydantic validation)
+# Test 4: Validação de entrada (Pydantic validation for core model) - units handled by their validators
 def test_input_validation():
-    with pytest.raises(ValueError, match="Input should be greater than 0"): # Pydantic v2 gt error
-        ProjectileLaunchParams(initial_velocity=-10, launch_angle=45, initial_height=0)
-
-    with pytest.raises(ValueError, match="Input should be greater than 0"): # Matches default message for gt
-        ProjectileLaunchParams(initial_velocity=0, launch_angle=45, initial_height=0)
-
-    with pytest.raises(ValueError, match="Input should be less than 90"): # lt=90
-        ProjectileLaunchParams(initial_velocity=10, launch_angle=90, initial_height=0)
-
-    with pytest.raises(ValueError, match="Input should be greater than or equal to 0"): # ge=0
-        ProjectileLaunchParams(initial_velocity=10, launch_angle=-5, initial_height=0)
-
-    with pytest.raises(ValueError, match="Input should be greater than or equal to 0"): # ge=0
-        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=-10)
-
-    with pytest.raises(ValueError, match="Input should be greater than 0"): # gt=0
-        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=0)
     with pytest.raises(ValueError, match="Input should be greater than 0"):
-        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=-9.81)
+        ProjectileLaunchParams(initial_velocity=-10, launch_angle=45, initial_height=0)
+    # ... (other validation tests remain the same as they test core model constraints, not units)
 
 # Test 5: Trajetória com pontos específicos (exemplo simples com g=10)
 def test_trajectory_specific_point():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=30, initial_height=0, gravity=10)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=30, initial_height=0, gravity=10,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    # v0x = 10 * cos(30) = 8.660254 m/s; v0y = 10 * sin(30) = 5 m/s
-    # Time to max height (t_peak) = v0y / g = 5 / 10 = 0.5s
-    # At t=0.5s: x = 4.330127 m; y = 1.25 m (max height)
-    # Total time = 1.0s; Max range = 8.660254 m
 
     assert math.isclose(result.max_height, 1.25, rel_tol=1e-3)
     assert math.isclose(result.total_time, 1.0, rel_tol=1e-3)
     assert math.isclose(result.max_range, 8.660, rel_tol=1e-3)
+    assert result.max_range_unit == "m"
 
     found_peak_time_point = False
     for point in result.trajectory:
-        if math.isclose(point.time, 0.5, abs_tol=0.025): # time_step is 0.05, so abs_tol should be half of that
-            assert math.isclose(point.x, 4.330, rel_tol=1e-2), f"X at t=0.5s: Expected ~4.33, got {point.x}"
-            assert math.isclose(point.y, 1.25, rel_tol=1e-2),  f"Y at t=0.5s: Expected ~1.25, got {point.y}"
+        if math.isclose(point.time, 0.5, abs_tol=0.025): # time_step is 0.05
+            assert math.isclose(point.x, 4.330, rel_tol=1e-2)
+            assert math.isclose(point.y, 1.25, rel_tol=1e-2)
             found_peak_time_point = True
             break
-    assert found_peak_time_point, "Trajectory point at peak time t=0.5s not found or values incorrect."
+    assert found_peak_time_point
     assert result.parameters_used == params
 
-# Test for edge case angle near 0 (e.g. 0.001 degrees)
+# Test for edge case angle near 0
 def test_very_low_angle_launch():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=0.001, initial_height=0, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=0.001, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    assert result.max_height > 0 and result.max_height < 0.01 # Should be very small
-    assert result.total_time > 0 and result.total_time < 0.01 # Should be very small
-    assert result.max_range > 0 and result.max_range < 0.1   # sin(2*angle) will be small
+    assert result.max_height > 0 and result.max_height < 0.01
+    assert result.total_time > 0 and result.total_time < 0.01
+    assert result.max_range > 0 and result.max_range < 0.1
+    assert result.max_range_unit == "m"
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
 
-# Test for edge case angle near 90 (e.g. 89.999 degrees, valid as per lt=90)
+# Test for edge case angle near 90
 def test_very_high_angle_launch():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=89.999, initial_height=0, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=89.999, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    # Expect max_height to be close to v0^2 / (2g) = 100 / 19.62 = 5.0969m
-    # Expect total_time to be close to 2*v0/g = 20 / 9.81 = 2.0387s
-    # Expect max_range to be very small
     assert math.isclose(result.max_height, 5.0969, rel_tol=1e-3)
     assert math.isclose(result.total_time, 2.0387, rel_tol=1e-3)
-    assert result.max_range < 0.01 # Range should be very small as cos(angle) is tiny
+    assert result.max_range < 0.01
+    assert result.max_range_unit == "m"
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
 
 # Test to ensure parameters_used is correctly populated
 def test_parameters_used_population():
-    params = ProjectileLaunchParams(initial_velocity=25, launch_angle=35, initial_height=5, gravity=9.8) # Using 9.8 for variety
+    params = ProjectileLaunchParams(
+        initial_velocity=25, launch_angle=35, initial_height=5, gravity=9.8,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-    assert result.parameters_used.initial_velocity == params.initial_velocity
-    assert result.parameters_used.launch_angle == params.launch_angle
-    assert result.parameters_used.initial_height == params.initial_height
-    assert result.parameters_used.gravity == params.gravity
-    # Or simply:
     assert result.parameters_used == params
 
 # Test with different gravity (e.g., Moon's gravity)
 def test_different_gravity_moon():
     moon_gravity = 1.62
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=moon_gravity)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=45, initial_height=0, gravity=moon_gravity,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    # Max Range (R)  = (v0^2 * sin(2*angle)) / g = (100 * 1) / 1.62 = 61.728 m
-    # Max Height (H) = (v0^2 * sin^2(angle)) / (2 * g) = (100 * 0.5) / (2 * 1.62) = 15.432 m
-    # Total Time (T) = (2 * v0 * sin(angle)) / g = (2 * 10 * sqrt(2)/2) / 1.62 = 8.729 s (approx)
-
     assert math.isclose(result.max_range, 61.728, rel_tol=1e-3)
     assert math.isclose(result.max_height, 15.432, rel_tol=1e-3)
     assert math.isclose(result.total_time, 8.729, rel_tol=1e-3)
-    assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
+    assert result.max_range_unit == "m"
     assert result.parameters_used.gravity == moon_gravity
+    assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
 
-# Test for a case where the projectile doesn't move much due to very low velocity but valid angle/height
+# Test for a case where the projectile doesn't move much
 def test_low_velocity_on_ground():
-    params = ProjectileLaunchParams(initial_velocity=0.01, launch_angle=45, initial_height=0, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=0.01, launch_angle=45, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
     assert result.max_range < 1e-3
     assert result.max_height < 1e-4
     assert result.total_time < 1e-2
+    assert result.max_range_unit == "m"
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
 
-# Test for launch from a significant height with a slightly upward angle
+# Test for launch from a significant height with an upward angle
 def test_launch_from_height_upward_angle():
-    params = ProjectileLaunchParams(initial_velocity=10, launch_angle=30, initial_height=20, gravity=9.81)
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=30, initial_height=20, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
     result = module.run_simulation(params)
-
-    # v0y = 10 * sin(30) = 5 m/s
-    # Time to reach peak from y0: t_to_peak_from_y0 = v0y / g = 5 / 9.81 = 0.5096s
-    # Height gained from y0 to peak: h_gain = v0y^2 / (2g) = 25 / (2 * 9.81) = 1.274 m
-    # Absolute max height = y0 + h_gain = 20 + 1.274 = 21.274 m
     assert math.isclose(result.max_height, 21.274, rel_tol=1e-3)
-
-    # Time from peak (at y_max) to ground (y=0): t_fall = sqrt(2 * y_max / g) = sqrt(2 * 21.274 / 9.81) = sqrt(4.337) = 2.0825s
-    # Total time = t_to_peak_from_y0 + t_fall = 0.5096 + 2.0825 = 2.5921s
-    # This can also be found by solving y(t) = y0 + v0y*t - 0.5*g*t^2 = 0 for t.
-    # -4.905*t^2 + 5*t + 20 = 0. Using quadratic formula: t = (-5 +- sqrt(25 - 4*(-4.905)*20)) / (2*-4.905)
-    # t = (-5 +- sqrt(25 + 392.4)) / -9.81 = (-5 +- sqrt(417.4)) / -9.81 = (-5 +- 20.43) / -9.81
-    # Positive t = (-5 + 20.43) / 9.81 = 15.43 / 9.81 = 1.5728s (This is time from y0 if it could go through ground until v is same magnitude downwards) - no, this is wrong.
-    # Positive t for y=0:  t = (v0y + sqrt(v0y^2 + 2*g*y0)) / g = (5 + sqrt(25 + 2*9.81*20)) / 9.81
-    # t = (5 + sqrt(25 + 392.4)) / 9.81 = (5 + sqrt(417.4)) / 9.81 = (5 + 20.4303) / 9.81 = 25.4303 / 9.81 = 2.5922s
-
     assert math.isclose(result.total_time, 2.5922, rel_tol=1e-3)
-
-    # Max range = v0x * total_time = (10 * cos(30)) * 2.5922 = 8.66025 * 2.5922 = 22.449 m
     assert math.isclose(result.max_range, 22.449, rel_tol=1e-3)
-
+    assert result.max_range_unit == "m"
+    assert result.max_height_unit == "m"
     assert math.isclose(result.trajectory[-1].y, 0.0, abs_tol=1e-2)
     assert result.parameters_used == params
+
+# --- New Tests for Unit Conversion ---
+def test_input_conversion_velocity_kmh():
+    params = ProjectileLaunchParams(
+        initial_velocity=36, initial_velocity_unit="km/h", # 36 km/h = 10 m/s
+        launch_angle=45, initial_height=0, gravity=10.0, # Using g=10 for simpler math
+        initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
+    result = module.run_simulation(params)
+    # Expected results for v0=10m/s, angle=45, g=10, h0=0:
+    # Max Range = v0^2 / g = 100 / 10 = 10 m
+    # Max Height = (v0^2 * sin^2(45)) / (2g) = (100 * 0.5) / 20 = 2.5 m
+    # Total Time = (2 * v0 * sin(45)) / g = (2 * 10 * sqrt(2)/2) / 10 = sqrt(2) approx 1.414 s
+    assert math.isclose(result.max_range, 10.0, rel_tol=1e-3)
+    assert math.isclose(result.max_height, 2.5, rel_tol=1e-3)
+    assert math.isclose(result.total_time, 1.4142, rel_tol=1e-3)
+    assert result.max_range_unit == "m"
+    assert result.initial_velocity_x_unit == "m/s" # Output is SI
+
+def test_input_conversion_height_ft():
+    params = ProjectileLaunchParams(
+        initial_velocity=5, initial_velocity_unit="m/s",
+        launch_angle=0, # Horizontal launch
+        initial_height=10, initial_height_unit="ft", # 10 ft = 3.048 m
+        gravity=10.0, output_units=SI_OUTPUT_UNITS
+    )
+    result = module.run_simulation(params)
+    # Expected for y0 = 3.048m, v0x=5m/s, v0y=0, g=10:
+    # Time to fall: t = sqrt(2*y0/g) = sqrt(2*3.048/10) = sqrt(0.6096) approx 0.7807 s
+    # Max range = v0x * t = 5 * 0.7807 = 3.9035 m
+    # Max height = initial height = 3.048 m
+    assert math.isclose(result.max_range, 3.9035, rel_tol=1e-3)
+    assert math.isclose(result.max_height, 3.048, rel_tol=1e-3)
+    assert math.isclose(result.total_time, 0.7807, rel_tol=1e-3)
+    assert result.max_height_unit == "m"
+    assert result.max_range_unit == "m"
+
+def test_output_conversion_various_units():
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=45, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m",
+        output_units=OutputUnitSelection(
+            velocity_unit="km/h", time_unit="min", range_unit="km", height_unit="ft"
+        )
+    )
+    result = module.run_simulation(params)
+
+    # SI results first (from test_launch_45_degrees):
+    max_r_si = 10.1936  # m
+    max_h_si = 2.5484   # m
+    total_t_si = 1.4416 # s
+    v0x_si = 10 * math.cos(math.radians(45)) # approx 7.071 m/s
+    v0y_si = 10 * math.sin(math.radians(45)) # approx 7.071 m/s
+
+    expected_max_r_km = max_r_si * uc.KM_PER_M
+    expected_max_h_ft = max_h_si * uc.FT_PER_M
+    expected_total_t_min = total_t_si * uc.MIN_PER_S
+    expected_v0x_kmh = v0x_si * uc.M_PER_KM / uc.S_PER_H # This is wrong, should be v0x_si / (uc.M_PER_KM / uc.S_PER_H) or v0x_si * (uc.S_PER_H / uc.M_PER_KM) or 3.6
+    expected_v0x_kmh_corrected = v0x_si * 3.6 # m/s to km/h
+    expected_v0y_kmh_corrected = v0y_si * 3.6 # m/s to km/h
+
+
+    assert math.isclose(result.max_range, expected_max_r_km, rel_tol=1e-3)
+    assert result.max_range_unit == "km"
+    assert math.isclose(result.max_height, expected_max_h_ft, rel_tol=1e-3)
+    assert result.max_height_unit == "ft"
+    assert math.isclose(result.total_time, expected_total_t_min, rel_tol=1e-3)
+    assert result.total_time_unit == "min"
+    assert math.isclose(result.initial_velocity_x, expected_v0x_kmh_corrected, rel_tol=1e-3)
+    assert result.initial_velocity_x_unit == "km/h"
+    assert math.isclose(result.initial_velocity_y, expected_v0y_kmh_corrected, rel_tol=1e-3)
+    assert result.initial_velocity_y_unit == "km/h"
+
+    # Check a few trajectory points
+    # Last point: x should be in km, y in ft, time in s
+    # For trajectory, x is in range_unit, y is in height_unit. Time is always 's'.
+    if result.trajectory:
+        last_point = result.trajectory[-1]
+        # last_point.x is already converted to km by the module
+        assert math.isclose(last_point.x, expected_max_r_km, rel_tol=1e-2)
+        # last_point.y should be close to 0 ft
+        assert math.isclose(last_point.y, 0.0, abs_tol=0.1) # 0m converted to ft is 0ft. abs_tol for ft.
+        # last_point.time is in seconds
+        assert math.isclose(last_point.time, total_t_si, rel_tol=1e-3)
+
+# --- New Tests for Adaptive Trajectory Generation ---
+MIN_DESIRED_POINTS = 20
+MAX_POINTS_LIMIT = 2000
+
+def test_trajectory_adaptive_low_energy():
+    params = ProjectileLaunchParams(
+        initial_velocity=0.1, launch_angle=45, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
+    result = module.run_simulation(params)
+    # total_t for v0=0.1, angle=45, g=9.81 is (2*0.1*sin(45))/9.81 = 0.0144s
+    # Default time_step = 0.05. 0.0144 / 0.05 < MIN_DESIRED_POINTS (20)
+    # New time_step = 0.0144 / 20 = 0.00072s
+    # Num intervals = total_t / new_time_step = 20. Num points = 21.
+    assert len(result.trajectory) == MIN_DESIRED_POINTS + 1
+
+def test_trajectory_adaptive_high_energy_capped():
+    params = ProjectileLaunchParams(
+        initial_velocity=700, launch_angle=30, initial_height=0, gravity=9.81, # Results in ~2474 points with 0.05 step
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
+    # v0y = 700 * sin(30) = 350. total_t = 2 * 350 / 9.81 = 71.355 s
+    # Default num_intervals = 71.355 / 0.05 = 1427. This is < MAX_POINTS_LIMIT.
+    # Let's try velocity that WILL exceed it.
+    # If total_t / 0.05 > 2000 => total_t > 100s.
+    # 2 * v0y / g > 100 => v0y > 100 * g / 2 = 50 * 9.81 = 490.5
+    # v0 * sin(angle) > 490.5. Let angle=30, sin(30)=0.5. v0 * 0.5 > 490.5 => v0 > 981 m/s
+    params_high = ProjectileLaunchParams(
+        initial_velocity=1000, launch_angle=30, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
+    # total_t = (2 * 1000 * 0.5) / 9.81 = 1000 / 9.81 = 101.936 s
+    # Default steps = 101.936 / 0.05 = 2038.72 -> this should trigger capping.
+    # New time_step = 101.936 / 2000 = 0.050968
+    result = module.run_simulation(params_high)
+    assert len(result.trajectory) == MAX_POINTS_LIMIT + 1
+
+def test_trajectory_adaptive_standard_case():
+    params = ProjectileLaunchParams(
+        initial_velocity=10, launch_angle=45, initial_height=0, gravity=9.81,
+        initial_velocity_unit="m/s", initial_height_unit="m", output_units=SI_OUTPUT_UNITS
+    )
+    result = module.run_simulation(params)
+    # total_t approx 1.4416s. Default time_step 0.05s.
+    # num_intervals = 1.4416 / 0.05 = 28.832.
+    # This is > MIN_DESIRED_POINTS (20) and < MAX_POINTS_LIMIT (2000)
+    # So, time_step should remain 0.05.
+    # Expected points = floor(num_intervals) + 1 (for t=0) + 1 (for final point if not perfectly aligned)
+    # Or, more robustly, check it's NOT 21 and NOT 2001.
+    # The loop runs while current_time <= total_t + 1e-9.
+    # Number of points = floor(total_t / time_step) + 1. Potentially +1 if last point added separately.
+    # The logic is: `while current_time <= total_t_si + 1e-9`.
+    # Point for current_time=0. Then current_time becomes 0.05, 0.10, ...
+    # Number of steps = ceil(total_t / time_step). Points = Number of steps + 1 if t=0 is counted.
+    # Or simpler: total_t / time_step = 1.4416 / 0.05 = 28.832.
+    # loop runs for time = 0, 0.05, ..., 1.40. (29 points)
+    # Then final point at 1.4416s is added if not already close. (Potentially 30th point)
+    # The current implementation adds the final point if the last point's time is not close to total_t.
+    # If last point is at 1.40, and total_t is 1.4416, it will add one more. So 29+1 = 30.
+    # If last point is at 1.40, current_time becomes 1.45. Loop terminates.
+    # trajectory_points_si.append(TrajectoryPoint(time=current_time_si, x=x_si, y=y_si))
+    # So it will be 1.40. Then check `abs(trajectory_points_si[-1].time - total_t_si) > 1e-4`
+    # `abs(1.40 - 1.4416) > 1e-4` is true. So one more point is added.
+    # Expected points = floor(1.4416/0.05) + 1 (initial) + 1 (final adjustment) = 28 + 1 + 1 = 30.
+    # Let's verify:
+    # t=0 (1)
+    # t=0.05 (2)
+    # ...
+    # t=1.40 (0.05 * 28) -> 28+1 = 29th point
+    # current_time becomes 1.45. Loop condition: 1.45 <= 1.4416 + 1e-9 is false.
+    # Last point in loop is at t=1.40.
+    # Then, `if not trajectory_points_si or abs(trajectory_points_si[-1].time - total_t_si) > 1e-4`
+    # `abs(1.40 - 1.4416) > 1e-4` is true. So, point at `total_t_si` is added.
+    # So, number of points will be `floor(total_t_si / time_step_si) + 1 + 1`
+    # `floor(1.4416 / 0.05)` = 28. So `28 + 1 + 1 = 30`.
+
+    # However, the adaptive logic for time_step_si is:
+    # if (total_t_si / time_step_si) < min_desired_points: ...
+    # 1.4416 / 0.05 = 28.832. This is > 20. So time_step_si remains 0.05.
+    # if (total_t_si / time_step_si) > max_points_limit: ... (28.832 is not > 2000)
+
+    assert len(result.trajectory) > MIN_DESIRED_POINTS + 1 # Greater than 21
+    assert len(result.trajectory) < MAX_POINTS_LIMIT + 1 # Less than 2001
+    # For this specific case, total_t_si = 1.4416s, time_step_si = 0.05s
+    # num_generated_in_loop = 0
+    # temp_current_time = 0.0
+    # while temp_current_time <= total_t_si + 1e-9:
+    #    num_generated_in_loop+=1
+    #    temp_current_time += 0.05
+    #    if num_generated_in_loop > 2000+10: break # safety
+    # num_generated_in_loop is 29 (for t=0 to t=1.40)
+    # Then one more point is added by the final adjustment logic. So 30.
+    assert len(result.trajectory) == 30
+
+# Re-add the input validation tests that might have been accidentally removed by diff markers
+def test_input_validation_original(): # Renamed to avoid conflict if parts were kept
+    with pytest.raises(ValueError, match="Input should be greater than 0"):
+        ProjectileLaunchParams(initial_velocity=-10, launch_angle=45, initial_height=0)
+
+    with pytest.raises(ValueError, match="Input should be greater than 0"):
+        ProjectileLaunchParams(initial_velocity=0, launch_angle=45, initial_height=0)
+
+    with pytest.raises(ValueError, match="Input should be less than 90"):
+        ProjectileLaunchParams(initial_velocity=10, launch_angle=90, initial_height=0)
+
+    with pytest.raises(ValueError, match="Input should be greater than or equal to 0"):
+        ProjectileLaunchParams(initial_velocity=10, launch_angle=-5, initial_height=0)
+
+    with pytest.raises(ValueError, match="Input should be greater than or equal to 0"):
+        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=-10)
+
+    with pytest.raises(ValueError, match="Input should be greater than 0"):
+        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=0)
+    with pytest.raises(ValueError, match="Input should be greater than 0"):
+        ProjectileLaunchParams(initial_velocity=10, launch_angle=45, initial_height=0, gravity=-9.81)

--- a/backend/simulations/physics/unit_conversion.py
+++ b/backend/simulations/physics/unit_conversion.py
@@ -1,0 +1,73 @@
+# Conversion factors
+KM_PER_M = 0.001
+M_PER_KM = 1000.0  # Corrected to float
+FT_PER_M = 3.28084
+M_PER_FT = 0.3048
+MI_PER_M = 0.000621371
+M_PER_MI = 1609.34
+S_PER_H = 3600.0 # Corrected to float
+MIN_PER_S = 1.0 / 60.0
+S_PER_MIN = 60.0 # Corrected to float
+
+# Allowed unit strings (for reference, actual validation is in models)
+# VELOCITY_UNITS = ["m/s", "km/h", "ft/s", "mph"]
+# LENGTH_UNITS_INPUT = ["m", "ft"]
+# LENGTH_UNITS_OUTPUT = ["m", "km", "ft", "mi"]
+# TIME_UNITS_OUTPUT = ["s", "min"]
+
+def convert_velocity_to_base(value: float, unit: str) -> float:
+    """Converts velocity from a given unit to m/s (base unit)."""
+    if unit == "m/s":
+        return value
+    elif unit == "km/h":
+        return value * M_PER_KM / S_PER_H
+    elif unit == "ft/s":
+        return value * M_PER_FT
+    elif unit == "mph":
+        return value * M_PER_MI / S_PER_H
+    else:
+        raise ValueError(f"Unknown velocity unit for conversion to base: {unit}")
+
+def convert_length_to_base(value: float, unit: str) -> float:
+    """Converts length from a given unit to meters (base unit)."""
+    if unit == "m":
+        return value
+    elif unit == "ft":
+        return value * M_PER_FT
+    else:
+        raise ValueError(f"Unknown length unit for conversion to base: {unit}")
+
+def convert_velocity_from_base(value_mps: float, target_unit: str) -> float:
+    """Converts velocity from m/s (base unit) to a target unit."""
+    if target_unit == "m/s":
+        return value_mps
+    elif target_unit == "km/h":
+        return value_mps * KM_PER_M * S_PER_H
+    elif target_unit == "ft/s":
+        return value_mps / M_PER_FT # Equivalent to value_mps * FT_PER_M
+    elif target_unit == "mph":
+        return value_mps * MI_PER_M * S_PER_H
+    else:
+        raise ValueError(f"Unknown target velocity unit for conversion from base: {target_unit}")
+
+def convert_length_from_base(value_m: float, target_unit: str) -> float:
+    """Converts length from meters (base unit) to a target unit."""
+    if target_unit == "m":
+        return value_m
+    elif target_unit == "km":
+        return value_m * KM_PER_M
+    elif target_unit == "ft":
+        return value_m * FT_PER_M
+    elif target_unit == "mi":
+        return value_m * MI_PER_M
+    else:
+        raise ValueError(f"Unknown target length unit for conversion from base: {target_unit}")
+
+def convert_time_from_base(value_s: float, target_unit: str) -> float:
+    """Converts time from seconds (base unit) to a target unit."""
+    if target_unit == "s":
+        return value_s
+    elif target_unit == "min":
+        return value_s * MIN_PER_S
+    else:
+        raise ValueError(f"Unknown target time unit for conversion from base: {target_unit}")


### PR DESCRIPTION
Implemented a comprehensive unit conversion system for the projectile launch physics module. You can now specify units for input parameters (initial velocity, initial height) and select desired units for output results (velocities, time, range, height). All internal calculations are performed in SI units, with conversions handled at the API boundary. Supported units include various metric and imperial options.

Additionally, the trajectory point generation mechanism was made adaptive. It now ensures a minimum number of points for low-energy launches (improving visualization) and caps the number of points for very long trajectories (maintaining performance).

Key changes:
- Added `unit_conversion.py` for conversion logic.
- Modified `models_projectile.py` for API unit specification.
- Updated `projectile_module.py` for core logic changes.
- Expanded `test_projectile_module.py` for new features.
- Updated README, Handover, and Architectural Decisions documents.

These changes address your feedback on visualization proportionality for low-value launches and the lack of unit flexibility.