### PR TITLE
fix: Correct payload for output units to enable backend conversion

### DIFF
--- a/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
+++ b/frontend/src/routes/experiments/physics/projectile-launch/+page.svelte
@@ -45,9 +45,10 @@
       initial_velocity_unit: initialVelocityUnit,
       initial_height_unit: initialHeightUnit,
       output_units: {
-        distance: outputDistanceUnit,
-        velocity: outputVelocityUnit,
-        time: outputTimeUnit
+        velocity_unit: outputVelocityUnit,
+        time_unit: outputTimeUnit,
+        range_unit: outputDistanceUnit,
+        height_unit: outputDistanceUnit // Assuming height_unit uses the same selection as range_unit
       }
     };
 


### PR DESCRIPTION
Addresses the issue where selected output units in the frontend were not being applied to the simulation results. This was due to a mismatch in the field names for the `output_units` object sent in the API payload compared to what the backend Pydantic model (`OutputUnitSelection`) expected.

The `startSimulation` function in the projectile launch frontend has been updated to send `output_units` with the correct field names:
- `velocity_unit` (was `velocity`)
- `time_unit` (was `time`)
- `range_unit` (was `distance`, now specifically for range)
- `height_unit` (was `distance`, now specifically for height)

The `outputDistanceUnit` frontend state variable is now mapped to both `range_unit` and `height_unit` in the payload, ensuring consistent distance unit selection for these results.

This change allows the backend to correctly interpret the desired output units and perform the necessary conversions, so the frontend now displays results in the units selected by you.