### PR TITLE
Fix: Make allele input fields required for clarity

### DIFF
--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -147,11 +147,11 @@
       <div class="form-grid">
         <div>
           <label for="dominant_allele">Alelo Dominante:</label>
-          <input type="text" id="dominant_allele" bind:value={params.dominant_allele} maxlength="1" pattern="[a-zA-Z]{1}">
+          <input type="text" id="dominant_allele" bind:value={params.dominant_allele} maxlength="1" pattern="[a-zA-Z]{1}" required>
         </div>
         <div>
           <label for="recessive_allele">Alelo Recessivo:</label>
-          <input type="text" id="recessive_allele" bind:value={params.recessive_allele} maxlength="1" pattern="[a-zA-Z]{1}">
+          <input type="text" id="recessive_allele" bind:value={params.recessive_allele} maxlength="1" pattern="[a-zA-Z]{1}" required>
         </div>
         <div>
           <label for="dominant_phenotype_description">Descrição do Fenótipo Dominante:</label>


### PR DESCRIPTION
Based on your feedback regarding validation messages on the allele input fields in the Mendelian genetics experiment:

The `dominant_allele` and `recessive_allele` input fields in `frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte` have been updated by adding the `required` HTML attribute.

Previously, these fields had a `pattern` attribute but were not explicitly `required`. This could lead to confusing validation messages if the field was empty, as browser behavior for pattern validation on optional empty fields can vary or be non-intuitive during form submission attempts.

By making these fields `required`:
- If a field is left empty, the browser will prompt you to fill it (e.g., "Please fill out this field").
- If a field contains a value that does not match the pattern `[a-zA-Z]{1}` (e.g., a digit or symbol), the browser will prompt you to match the format (e.g., "Please match the requested format.").

This change aims to provide clearer and more standard HTML5 validation feedback to you, ensuring that allele definitions are explicitly provided and correctly formatted.