### PR TITLE
Fix: Correct type hint for parameters_used in MendelianCrossResult

### DIFF
--- a/backend/simulations/biology/models_mendelian_genetics.py
+++ b/backend/simulations/biology/models_mendelian_genetics.py
@@ -61,7 +61,7 @@ class MendelianCrossResult(BaseSimulationResult):
     punnett_square: List[List[str]]
     offspring_genotypes: List[GenotypeProportion]
     offspring_phenotypes: List[PhenotypeProportion]
-    parameters_used: MendelianCrossParams # type: ignore[assignment]
+    parameters_used: Dict[str, Any]
     # As per BaseSimulationResult, parameters_used is Dict[str, Any].
     # Pydantic v2 handles the assignment of a model instance by calling model_dump() if needed.
     # If strict typing without Pydantic's implicit conversion is required, this could be:


### PR DESCRIPTION
The Mendelian genetics simulation was failing to return results to the frontend, likely due to a backend serialization error.

In `backend/simulations/biology/models_mendelian_genetics.py`, the `MendelianCrossResult` class had a type inconsistency for its `parameters_used` field. It was annotated as `MendelianCrossParams` but was being assigned a dictionary (from `updated_params.model_dump()`). This mismatch could lead to an `AttributeError` during FastAPI's JSON response serialization, resulting in a 500 Internal Server Error.

This commit changes the type annotation of `parameters_used` in `MendelianCrossResult` to `Dict[str, Any]`. This aligns it with the actual data type being assigned and with the type definition in its base class, `BaseSimulationResult`.

This correction should allow FastAPI to properly serialize the simulation results, enabling the frontend to receive and display them.