### PR TITLE
Here's the rewritten message:

### DIFF
--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -18,9 +18,23 @@
   let simulationResult = null;
   let isLoading = false;
   let error = null;
+  let dominantAlleleError = '';
 
   $: parent1GenotypeError = validateGenotypeInput(params.parent1_genotype);
   $: parent2GenotypeError = validateGenotypeInput(params.parent2_genotype);
+
+  $: {
+    const allele = params.dominant_allele;
+    if (allele === '') {
+      dominantAlleleError = 'Alelo Dominante é obrigatório.';
+    } else if (allele && allele.length !== 1) {
+      dominantAlleleError = 'Alelo Dominante deve ter exatamente 1 caractere.';
+    } else if (allele && !/^[a-zA-Z]$/.test(allele)) {
+      dominantAlleleError = 'Alelo Dominante deve ser uma letra (A-Z, a-z).';
+    } else {
+      dominantAlleleError = '';
+    }
+  }
 
   function validateGenotypeInput(genotype) {
     // 1. Handle null or undefined genotype
@@ -147,7 +161,10 @@
       <div class="form-grid">
         <div>
           <label for="dominant_allele">Alelo Dominante:</label>
-          <input type="text" id="dominant_allele" bind:value={params.dominant_allele} maxlength="1" pattern="[a-zA-Z]{1}" required>
+          <input type="text" id="dominant_allele" bind:value={params.dominant_allele} maxlength="1" required>
+          {#if dominantAlleleError}
+            <small class="input-error">{dominantAlleleError}</small>
+          {/if}
         </div>
         <div>
           <label for="recessive_allele">Alelo Recessivo:</label>
@@ -164,7 +181,7 @@
       </div>
     </fieldset>
 
-    <button type="submit" class="submit-button" disabled={isLoading || parent1GenotypeError || parent2GenotypeError}>
+    <button type="submit" class="submit-button" disabled={isLoading || parent1GenotypeError || parent2GenotypeError || !!dominantAlleleError}>
       {#if isLoading}
         Calculando Proporções...
       {:else}


### PR DESCRIPTION
Feat: Implement custom Svelte validation for dominant allele input

This addresses reports of persistent 'Please match the requested format' messages for the dominant allele field in your Mendelian genetics experiment. I've introduced custom, Svelte-based validation for this specific input as an experimental approach to provide you with clearer and more controlled feedback.

Changes in `frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte`:
- I removed the `pattern` attribute from the `dominant_allele` input field to bypass HTML5 pattern validation for it. The `required` and `maxlength="1"` attributes are retained.
- I added a reactive variable `dominantAlleleError` to the Svelte script.
- I implemented a reactive Svelte block (`$:`) that validates the `params.dominant_allele` value:
    - It checks if the field is empty (handling the `required` constraint).
    - It checks if the value is a single character (though `maxlength` should also enforce this).
    - It checks if the character is an alphabet letter (A-Z, a-z).
- The custom `dominantAlleleError` message will now be displayed near the input field.
- I integrated `dominantAlleleError` into the submit button's `disabled` condition.

The `recessive_allele` input field retains its HTML5 pattern validation for comparison. This change aims to improve your experience by offering more specific error messages and avoiding potential quirks with browser-based pattern validation for the dominant allele field.