### PR TITLE
Fix: Extend custom Svelte validation to recessive allele input

### DIFF
--- a/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
+++ b/frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte
@@ -19,6 +19,7 @@
   let isLoading = false;
   let error = null;
   let dominantAlleleError = '';
+  let recessiveAlleleError = '';
 
   $: parent1GenotypeError = validateGenotypeInput(params.parent1_genotype);
   $: parent2GenotypeError = validateGenotypeInput(params.parent2_genotype);
@@ -33,6 +34,19 @@
       dominantAlleleError = 'Alelo Dominante deve ser uma letra (A-Z, a-z).';
     } else {
       dominantAlleleError = '';
+    }
+  }
+
+  $: {
+    const allele = params.recessive_allele;
+    if (allele === '') {
+      recessiveAlleleError = 'Alelo Recessivo é obrigatório.';
+    } else if (allele && allele.length !== 1) {
+      recessiveAlleleError = 'Alelo Recessivo deve ter exatamente 1 caractere.';
+    } else if (allele && !/^[a-zA-Z]$/.test(allele)) {
+      recessiveAlleleError = 'Alelo Recessivo deve ser uma letra (A-Z, a-z).';
+    } else {
+      recessiveAlleleError = '';
     }
   }
 
@@ -168,7 +182,10 @@
         </div>
         <div>
           <label for="recessive_allele">Alelo Recessivo:</label>
-          <input type="text" id="recessive_allele" bind:value={params.recessive_allele} maxlength="1" pattern="[a-zA-Z]{1}" required>
+          <input type="text" id="recessive_allele" bind:value={params.recessive_allele} maxlength="1" required>
+          {#if recessiveAlleleError}
+            <small class="input-error">{recessiveAlleleError}</small>
+          {/if}
         </div>
         <div>
           <label for="dominant_phenotype_description">Descrição do Fenótipo Dominante:</label>
@@ -181,7 +198,7 @@
       </div>
     </fieldset>
 
-    <button type="submit" class="submit-button" disabled={isLoading || parent1GenotypeError || parent2GenotypeError || !!dominantAlleleError}>
+    <button type="submit" class="submit-button" disabled={isLoading || parent1GenotypeError || parent2GenotypeError || !!dominantAlleleError || !!recessiveAlleleError}>
       {#if isLoading}
         Calculando Proporções...
       {:else}


### PR DESCRIPTION
This commit extends the custom Svelte-based validation approach to the `recessive_allele` input field in the Mendelian genetics experiment. This follows positive feedback from you after similar custom validation was applied to the `dominant_allele` field, which resolved issues with confusing HTML5 pattern validation messages.

Changes in `frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte`:
- Removed the `pattern` attribute from the `recessive_allele` input field. The `required` and `maxlength="1"` attributes are retained.
- Added a reactive variable `recessiveAlleleError` to the Svelte script.
- Implemented a reactive Svelte block (`$:`) that validates `params.recessive_allele` and sets `recessiveAlleleError`, mirroring the logic for the dominant allele. This checks for empty input, character length, and whether the input is an alphabet letter.
- Displays the custom `recessiveAlleleError` message near the input field.
- Integrated `recessiveAlleleError` into the submit button's `disabled` condition.

With this change, both dominant and recessive allele inputs now use a consistent, custom Svelte-driven validation mechanism. This provides clearer, more specific error messages and avoids potential issues related to browser-specific HTML5 pattern validation behavior.