### PR TITLE
feat: Implement frontend for Acid-Base Titration experiment

### DIFF
--- a/HANDOVER_DOCUMENT.md
+++ b/HANDOVER_DOCUMENT.md
@@ -104,10 +104,20 @@ Para executar e testar a aplicação:
     *   Implementar criptografia (ex: usando a biblioteca `cryptography`) para proteger esses dados. Isso envolverá a modificação dos endpoints de salvar e carregar para criptografar/descriptografar os dados. Gerenciamento seguro de chaves será essencial.
 
 *   **Desenvolvimento do Frontend:**
-    *   A API backend está pronta para ser consumida. O próximo grande passo é desenvolver a interface do usuário (frontend React/Svelte conforme planejado) que interaja com esta API.
+    *   A API backend está pronta para ser consumida. Interfaces de usuário (frontend Svelte) foram desenvolvidas para interagir com esta API.
+    *   **Experimentos com Frontend Implementado:**
+        *   **Reação Ácido-Base Simples:** `frontend/src/routes/experiments/chemistry/acid-base/+page.svelte`
+        *   **Lançamento Oblíquo:** `frontend/src/routes/experiments/physics/projectile-launch/+page.svelte` (com funcionalidades avançadas de unidades e plotagem SVG da trajetória).
+        *   **Genética Mendeliana:** `frontend/src/routes/experiments/biology/mendelian-genetics/+page.svelte`
+        *   **Curva de Titulação Ácido-Base:**
+            *   Localização: `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`.
+            *   Descrição: Permite aos usuários configurar um analito (ácido ou base, especificando concentração, volume, e opcionalmente Ka/Kb para espécies fracas) e um titulante (ácido ou base forte, com nome, concentração). Os usuários também definem o processo de titulação (volume inicial, volume final e incremento de volume do titulante).
+            *   Funcionalidades: A interface envia esses parâmetros para o endpoint backend `/api/simulation/acid-base-titration/start`. Exibe a curva de titulação (pH vs. volume de titulante) resultante usando um gráfico SVG customizado. Também apresenta uma mensagem de status da simulação e um resumo dos parâmetros utilizados.
+            *   Backend Consumido: Utiliza o módulo de simulação `acid_base_titration_module.py` existente no backend.
+    *   O desenvolvimento de interfaces para outros módulos de simulação ou novas simulações pode seguir o padrão estabelecido.
 
 *   **Novos Experimentos:**
-    *   Adicionar mais simulações seguindo o padrão `SimulationModule`:
+    *   Adicionar mais simulações seguindo o padrão `SimulationModule` no backend:
         1.  Crie uma nova subpasta em `backend/simulations/<categoria>/`.
         2.  Defina `models_<experimento>.py` com os modelos Pydantic para parâmetros e resultados.
         3.  Implemente `<experimento>_module.py` herdando de `SimulationModule`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Atualmente, as seguintes simulações estão implementadas:
     *   Observe o Quadro de Punnett resultante e as proporções genotípicas e fenotípicas da prole.
     *   Acesse em: `http://localhost:5173/experiments/biology/mendelian-genetics`
 
+4.  **Química: Curva de Titulação Ácido-Base**
+    *   Simula uma curva de titulação ácido-base, permitindo configurar um analito (ácido/base, forte/fraco com Ka/Kb) e um titulante (ácido/base forte).
+    *   Permite definir concentrações, volumes, e o intervalo de adição do titulante.
+    *   Visualiza a variação do pH em função do volume de titulante adicionado através de um gráfico SVG.
+    *   Mostra os parâmetros utilizados na simulação e mensagens do backend.
+    *   Acesse em: `http://localhost:5173/experiments/chemistry/acid-base-titration`
+
 ## Automated Execution (Recommended)
 
 The `run_simulation.sh` script automates the setup and launch of both the backend and frontend components of the simulator. This is the recommended way to start the application.

--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -1,0 +1,463 @@
+<script>
+  let analyte_is_acid = true; // Default to acid
+  let acid_name = 'HCl';
+  let acid_concentration = 0.1;
+  let acid_volume = 50;
+  let acid_ka = ''; // Optional, so can be empty string
+
+  let base_name = 'NaOH';
+  let base_concentration = 0.1;
+  let base_volume = 50;
+  let base_kb = ''; // Optional
+
+  let titrant_is_acid = false; // Titrant is typically the opposite of analyte
+  let titrant_name = 'NaOH'; // Default titrant name, can be changed by user
+  let titrant_concentration = 0.1;
+  let initial_titrant_volume_ml = 0.0;
+  let final_titrant_volume_ml = 100;
+  let volume_increment_ml = 1;
+
+  // $: console.log({ analyte_is_acid, acid_name, acid_concentration, acid_volume, acid_ka, base_name, base_concentration, base_volume, base_kb, titrant_is_acid, titrant_name, titrant_concentration, initial_titrant_volume_ml, final_titrant_volume_ml, volume_increment_ml });
+
+  // Update titrant_is_acid based on analyte_is_acid
+  $: titrant_is_acid = !analyte_is_acid;
+
+  // Update titrant_name based on titrant_is_acid
+  // $: if (titrant_is_acid) {
+  //     titrant_name = acid_name || 'HCl'; // Default to analyte name or HCl
+  //   } else {
+  //     titrant_name = base_name || 'NaOH'; // Default to analyte name or NaOH
+  //   }
+
+
+  let simulationResults = null;
+  let titrationCurveData = [];
+  let errorMessage = '';
+  let isLoading = false;
+
+  // SVG Chart related variables
+  const width = 700; // SVG width
+  const height = 400; // SVG height
+  const padding = { top: 20, right: 20, bottom: 50, left: 50 }; // Adjusted bottom and left for labels
+  const svgWidth = width;
+  const svgHeight = height;
+
+  let svgPathD = '';
+  let xAxisTicks = [];
+  let yAxisTicks = [];
+
+  $: if (titrationCurveData && titrationCurveData.length > 0) {
+    updateChartVisuals();
+  }
+
+  function updateChartVisuals() {
+    if (!titrationCurveData || titrationCurveData.length === 0) {
+      svgPathD = '';
+      xAxisTicks = [];
+      yAxisTicks = [];
+      return;
+    }
+
+    const xValues = titrationCurveData.map(d => d.titrant_volume_added_ml);
+    const yValues = titrationCurveData.map(d => d.ph);
+
+    const minX = Math.min(...xValues);
+    const maxX = Math.max(...xValues);
+    const minY = 0; // pH typically 0-14
+    const maxY = 14;
+
+    const xScale = (val) => padding.left + ((val - minX) / (maxX - minX)) * (svgWidth - padding.left - padding.right);
+    const yScale = (val) => svgHeight - padding.bottom - ((val - minY) / (maxY - minY)) * (svgHeight - padding.top - padding.bottom);
+
+    svgPathD = "M" + titrationCurveData.map(d => `${xScale(d.titrant_volume_added_ml)},${yScale(d.ph)}`).join(" L");
+
+    // Generate X Axis Ticks (e.g., 5 ticks)
+    xAxisTicks = [];
+    const xTickCount = 5;
+    const xTickIncrement = (maxX - minX) / (xTickCount -1);
+    if (isFinite(xTickIncrement) && xTickIncrement > 0) {
+      for (let i = 0; i < xTickCount; i++) {
+        const value = minX + i * xTickIncrement;
+        xAxisTicks.push({ x: xScale(value), label: value.toFixed(1) });
+      }
+    } else if (xValues.length === 1) { // Single data point
+        xAxisTicks.push({ x: xScale(xValues[0]), label: xValues[0].toFixed(1) });
+    }
+
+
+    // Generate Y Axis Ticks (e.g., 0, 2, 4 ... 14)
+    yAxisTicks = [];
+    const yTickIncrement = 2;
+    for (let i = minY; i <= maxY; i += yTickIncrement) {
+      yAxisTicks.push({ y: yScale(i), label: i.toString() });
+    }
+  }
+
+
+  async function runSimulation() {
+    isLoading = true;
+    errorMessage = '';
+    simulationResults = null;
+    titrationCurveData = [];
+
+    let params = {
+      analyte_is_acid: analyte_is_acid,
+      titrant_is_acid: titrant_is_acid,
+      titrant_name: titrant_name,
+      titrant_concentration: parseFloat(titrant_concentration),
+      initial_titrant_volume_ml: parseFloat(initial_titrant_volume_ml),
+      final_titrant_volume_ml: parseFloat(final_titrant_volume_ml),
+      volume_increment_ml: parseFloat(volume_increment_ml),
+    };
+
+    if (analyte_is_acid) {
+      params.acid_name = acid_name;
+      params.acid_concentration = parseFloat(acid_concentration);
+      params.acid_volume = parseFloat(acid_volume);
+      params.acid_ka = acid_ka ? acid_ka : null; // Send null if empty
+      // Ensure base params are not sent, or set to null if backend expects them
+      params.base_name = null;
+      params.base_concentration = null;
+      params.base_volume = null;
+      params.base_kb = null;
+    } else {
+      params.base_name = base_name;
+      params.base_concentration = parseFloat(base_concentration);
+      params.base_volume = parseFloat(base_volume);
+      params.base_kb = base_kb ? base_kb : null; // Send null if empty
+      // Ensure acid params are not sent
+      params.acid_name = null;
+      params.acid_concentration = null;
+      params.acid_volume = null;
+      params.acid_ka = null;
+    }
+
+    // params.titrant_name is already bound and set from its input field.
+    // The backend will determine if it's an acid or base based on titrant_is_acid.
+
+    // Client-side validation for volumes
+    if (parseFloat(final_titrant_volume_ml) <= parseFloat(initial_titrant_volume_ml)) {
+      errorMessage = "O Volume Final de Titulante deve ser maior que o Volume Inicial.";
+      isLoading = false;
+      return;
+    }
+    if (parseFloat(volume_increment_ml) <= 0) {
+      errorMessage = "O Incremento de Volume deve ser um valor positivo.";
+      isLoading = false;
+      return;
+    }
+    // Basic check for Ka/Kb format (optional, simple check for 'e' or numbers)
+    const scientificNotationPattern = /^-?\d+(\.\d+)?[eE][-+]?\d+$/;
+    if (acid_ka && !scientificNotationPattern.test(acid_ka) && isNaN(parseFloat(acid_ka))) {
+        errorMessage = "Ka do ácido parece inválido. Use notação científica (ex: 1.8e-5) ou um número.";
+        isLoading = false;
+        return;
+    }
+    if (base_kb && !scientificNotationPattern.test(base_kb) && isNaN(parseFloat(base_kb))) {
+        errorMessage = "Kb da base parece inválido. Use notação científica (ex: 1.8e-5) ou um número.";
+        isLoading = false;
+        return;
+    }
+
+    try {
+      const response = await fetch('/api/simulation/acid-base-titration/start', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+
+      if (!response.ok) {
+        let errorData;
+        try {
+          errorData = await response.json();
+        } catch (e) {
+          errorData = { detail: "Erro desconhecido ao processar a resposta do servidor." };
+        }
+        errorMessage = `Erro ${response.status}: ${errorData.detail || response.statusText}`;
+        if (errorData.errors) {
+          errorMessage += ` Detalhes: ${JSON.stringify(errorData.errors)}`;
+        }
+      } else {
+        const data = await response.json();
+        simulationResults = data;
+        if (data && data.titration_curve) {
+          titrationCurveData = data.titration_curve;
+        }
+      }
+    } catch (error) {
+      console.error('Fetch error:', error);
+      errorMessage = `Erro ao conectar com o servidor: ${error.message}`;
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<main class="container mx-auto p-4">
+  <h1 class="text-3xl font-bold text-center my-8 text-primary-700">Curva de Titulação Ácido-Base</h1>
+
+  <form on:submit|preventDefault={runSimulation}>
+    <section class="mb-8 p-6 bg-white shadow-md rounded-lg">
+      <h2 class="text-2xl font-semibold mb-6 text-gray-700 border-b pb-2">Parâmetros da Simulação</h2>
+
+      <!-- Analyte Selection -->
+      <div class="mb-6">
+        <span class="block text-lg font-medium text-gray-700 mb-2">Analito (Substância a ser Titulada):</span>
+        <div class="flex items-center space-x-4">
+          <label class="flex items-center">
+            <input type="radio" name="analyte_type" bind:group={analyte_is_acid} value={true} class="radio radio-primary">
+            <span class="ml-2">Ácido</span>
+          </label>
+          <label class="flex items-center">
+            <input type="radio" name="analyte_type" bind:group={analyte_is_acid} value={false} class="radio radio-primary">
+            <span class="ml-2">Base</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- Analyte Details -->
+      {#if analyte_is_acid}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          <div>
+            <label for="acid_name" class="block text-sm font-medium text-gray-700">Nome do Ácido:</label>
+            <input type="text" id="acid_name" bind:value={acid_name} class="input input-bordered w-full mt-1" placeholder="Ex: HCl" required>
+          </div>
+          <div>
+            <label for="acid_concentration" class="block text-sm font-medium text-gray-700">Concentração do Ácido (mol/L):</label>
+            <input type="number" step="any" id="acid_concentration" bind:value={acid_concentration} class="input input-bordered w-full mt-1" placeholder="Ex: 0.1" min="0" required>
+          </div>
+          <div>
+            <label for="acid_volume" class="block text-sm font-medium text-gray-700">Volume do Ácido (mL):</label>
+            <input type="number" step="any" id="acid_volume" bind:value={acid_volume} class="input input-bordered w-full mt-1" placeholder="Ex: 50" min="0" required>
+          </div>
+          <div>
+            <label for="acid_ka" class="block text-sm font-medium text-gray-700">Constante de Acidez (Ka) (opcional):</label>
+            <input type="text" id="acid_ka" bind:value={acid_ka} class="input input-bordered w-full mt-1" placeholder="Ex: 1.8e-5 (para ácido fraco)">
+          </div>
+        </div>
+      {:else}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          <div>
+            <label for="base_name" class="block text-sm font-medium text-gray-700">Nome da Base:</label>
+            <input type="text" id="base_name" bind:value={base_name} class="input input-bordered w-full mt-1" placeholder="Ex: NaOH" required>
+          </div>
+          <div>
+            <label for="base_concentration" class="block text-sm font-medium text-gray-700">Concentração da Base (mol/L):</label>
+            <input type="number" step="any" id="base_concentration" bind:value={base_concentration} class="input input-bordered w-full mt-1" placeholder="Ex: 0.1" min="0" required>
+          </div>
+          <div>
+            <label for="base_volume" class="block text-sm font-medium text-gray-700">Volume da Base (mL):</label>
+            <input type="number" step="any" id="base_volume" bind:value={base_volume} class="input input-bordered w-full mt-1" placeholder="Ex: 50" min="0" required>
+          </div>
+          <div>
+            <label for="base_kb" class="block text-sm font-medium text-gray-700">Constante de Basicidade (Kb) (opcional):</label>
+            <input type="text" id="base_kb" bind:value={base_kb} class="input input-bordered w-full mt-1" placeholder="Ex: 1.8e-5 (para base fraca)">
+          </div>
+        </div>
+      {/if}
+
+      <!-- Titrant Details -->
+      <div class="mb-6 border-t pt-6">
+        <h3 class="text-lg font-medium text-gray-700 mb-3">Titulante:</h3>
+        <div class="mb-4">
+          <label class="flex items-center">
+            <input type="checkbox" bind:checked={titrant_is_acid} class="checkbox checkbox-primary">
+            <span class="ml-2">Titulante é um ácido?</span>
+          </label>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label for="titrant_name" class="block text-sm font-medium text-gray-700">Nome do Titulante:</label>
+            <input type="text" id="titrant_name" bind:value={titrant_name} class="input input-bordered w-full mt-1" placeholder={titrant_is_acid ? "Ex: HCl" : "Ex: NaOH"} required>
+          </div>
+          <div>
+            <label for="titrant_concentration" class="block text-sm font-medium text-gray-700">Concentração do Titulante (mol/L):</label>
+            <input type="number" step="any" id="titrant_concentration" bind:value={titrant_concentration} class="input input-bordered w-full mt-1" placeholder="Ex: 0.1" min="0" required>
+          </div>
+        </div>
+      </div>
+
+      <!-- Titration Process Parameters -->
+      <div class="mb-6 border-t pt-6">
+        <h3 class="text-lg font-medium text-gray-700 mb-3">Processo de Titulação:</h3>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div>
+            <label for="initial_titrant_volume_ml" class="block text-sm font-medium text-gray-700">Volume Inicial de Titulante (mL):</label>
+            <input type="number" step="any" id="initial_titrant_volume_ml" bind:value={initial_titrant_volume_ml} class="input input-bordered w-full mt-1" min="0" required>
+          </div>
+          <div>
+            <label for="final_titrant_volume_ml" class="block text-sm font-medium text-gray-700">Volume Final de Titulante (mL):</label>
+            <input type="number" step="any" id="final_titrant_volume_ml" bind:value={final_titrant_volume_ml} class="input input-bordered w-full mt-1" placeholder="Ex: 100" min="0" required>
+          </div>
+          <div>
+            <label for="volume_increment_ml" class="block text-sm font-medium text-gray-700">Incremento de Volume (mL):</label>
+            <input type="number" step="any" id="volume_increment_ml" bind:value={volume_increment_ml} class="input input-bordered w-full mt-1" placeholder="Ex: 1" min="0.0000000001" required>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-center mt-8">
+        <button type="submit" class="btn btn-primary btn-lg" disabled={isLoading}>
+          {#if isLoading}
+            <span class="loading loading-spinner"></span>
+            Simulando...
+          {:else}
+            Simular
+          {/if}
+        </button>
+      </div>
+    </section>
+  </form>
+
+  <section class="mb-8 p-6 bg-white shadow-md rounded-lg">
+    <h2 class="text-2xl font-semibold mb-6 text-gray-700 border-b pb-2">Resultados da Simulação</h2>
+
+    {#if isLoading}
+      <div class="text-center my-4 p-4">
+        <p class="text-lg text-blue-600 animate-pulse">Carregando resultados...</p>
+        <!-- You could add a more sophisticated spinner here if desired -->
+      </div>
+    {/if}
+
+    {#if errorMessage}
+      <div class="my-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-md shadow">
+        <h3 class="font-bold text-lg mb-2">Erro na Simulação:</h3>
+        <p>{errorMessage}</p>
+      </div>
+    {/if}
+
+    {#if simulationResults && !isLoading && !errorMessage}
+      <div class="mt-4 space-y-4">
+        {#if simulationResults.message}
+          <div class="p-4 bg-blue-50 border border-blue-300 text-blue-700 rounded-md shadow-sm">
+            <p><strong>Status da Simulação:</strong> {simulationResults.message}</p>
+          </div>
+        {/if}
+
+        {#if simulationResults.parameters_used}
+          <div class="p-4 bg-gray-50 border border-gray-200 rounded-md shadow-sm">
+            <h3 class="text-xl font-semibold text-gray-700 mb-3">Parâmetros Utilizados:</h3>
+            <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+              {#if simulationResults.parameters_used.analyte_is_acid}
+                <div class="col-span-full mb-1 font-medium text-gray-600">Analito (Ácido):</div>
+                <dt class="font-semibold text-gray-600">Nome:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.acid_name || 'N/A'}</dd>
+                <dt class="font-semibold text-gray-600">Concentração:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.acid_concentration} mol/L</dd>
+                <dt class="font-semibold text-gray-600">Volume:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.acid_volume} mL</dd>
+                {#if simulationResults.parameters_used.acid_ka}
+                  <dt class="font-semibold text-gray-600">Ka:</dt>
+                  <dd class="text-gray-800">{simulationResults.parameters_used.acid_ka}</dd>
+                {/if}
+              {:else}
+                <div class="col-span-full mb-1 font-medium text-gray-600">Analito (Base):</div>
+                <dt class="font-semibold text-gray-600">Nome:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.base_name || 'N/A'}</dd>
+                <dt class="font-semibold text-gray-600">Concentração:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.base_concentration} mol/L</dd>
+                <dt class="font-semibold text-gray-600">Volume:</dt>
+                <dd class="text-gray-800">{simulationResults.parameters_used.base_volume} mL</dd>
+                {#if simulationResults.parameters_used.base_kb}
+                  <dt class="font-semibold text-gray-600">Kb:</dt>
+                  <dd class="text-gray-800">{simulationResults.parameters_used.base_kb}</dd>
+                {/if}
+              {/if}
+
+              <div class="col-span-full mt-2 mb-1 font-medium text-gray-600">Titulante:</div>
+              <dt class="font-semibold text-gray-600">Tipo:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.titrant_is_acid ? 'Ácido' : 'Base'}</dd>
+              <dt class="font-semibold text-gray-600">Nome:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.titrant_name || 'N/A'}</dd>
+              <dt class="font-semibold text-gray-600">Concentração:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.titrant_concentration} mol/L</dd>
+
+              <div class="col-span-full mt-2 mb-1 font-medium text-gray-600">Intervalo de Titulação:</div>
+              <dt class="font-semibold text-gray-600">Volume Inicial:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.initial_titrant_volume_ml} mL</dd>
+              <dt class="font-semibold text-gray-600">Volume Final:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.final_titrant_volume_ml} mL</dd>
+              <dt class="font-semibold text-gray-600">Incremento:</dt>
+              <dd class="text-gray-800">{simulationResults.parameters_used.volume_increment_ml} mL</dd>
+            </dl>
+          </div>
+        {/if}
+
+        {#if simulationResults.equivalence_points_ml && simulationResults.equivalence_points_ml.length > 0}
+          <div class="p-4 bg-green-50 border border-green-300 text-green-700 rounded-md shadow-sm">
+            <p><strong>Pontos de Equivalência Detectados (mL):</strong> {simulationResults.equivalence_points_ml.join(', ')}</p>
+          </div>
+        {/if}
+      </div>
+    {/if}
+    <!-- The pre tag for raw JSON is now definitely removed/disabled by the logic above -->
+  </section>
+
+  <section class="mb-8 p-6 bg-white shadow-md rounded-lg">
+    <h2 class="text-2xl font-semibold mb-6 text-gray-700 border-b pb-2">Gráfico da Curva de Titulação</h2>
+    {#if titrationCurveData && titrationCurveData.length > 0}
+      <div class="chart-container" role="figure" aria-labelledby="chart-title">
+        <svg {width} {height} viewBox="0 0 {svgWidth} {svgHeight}" preserveAspectRatio="xMidYMin meet" aria-labelledby="chart-title-svg" aria-describedby="chart-desc-svg">
+          <title id="chart-title-svg">Curva de Titulação Ácido-Base</title>
+          <desc id="chart-desc-svg">Gráfico de pH em função do volume de titulante adicionado.</desc>
+
+          <!-- Y Axis (pH) -->
+          <line x1={padding.left} y1={padding.top} x2={padding.left} y2={svgHeight - padding.bottom} stroke="currentColor" />
+          {#each yAxisTicks as tick}
+            <g class="tick">
+              <line x1={padding.left - 5} y1={tick.y} x2={padding.left} y2={tick.y} stroke="currentColor" />
+              <text x={padding.left - 10} y={tick.y + 4} text-anchor="end" font-size="10">{tick.label}</text>
+            </g>
+          {/each}
+          <text x={padding.left - 35} y={padding.top + (svgHeight - padding.top - padding.bottom) / 2} transform="rotate(-90, {padding.left - 35}, {padding.top + (svgHeight - padding.top - padding.bottom) / 2})" text-anchor="middle" font-size="12">pH</text>
+
+          <!-- X Axis (Volume) -->
+          <line x1={padding.left} y1={svgHeight - padding.bottom} x2={svgWidth - padding.right} y2={svgHeight - padding.bottom} stroke="currentColor" />
+          {#each xAxisTicks as tick}
+            <g class="tick">
+              <line x1={tick.x} y1={svgHeight - padding.bottom} x2={tick.x} y2={svgHeight - padding.bottom + 5} stroke="currentColor" />
+              <text x={tick.x} y={svgHeight - padding.bottom + 15} text-anchor="middle" font-size="10">{tick.label}</text>
+            </g>
+          {/each}
+          <text x={padding.left + (svgWidth - padding.left - padding.right) / 2} y={svgHeight - padding.bottom + 35} text-anchor="middle" font-size="12">Volume do Titulante Adicionado (mL)</text>
+
+          <!-- Titration Curve Path -->
+          <path d={svgPathD} fill="none" stroke="var(--color-primary-500, #3b82f6)" stroke-width="2" />
+
+        </svg>
+      </div>
+    {:else if isLoading}
+      <p>Gerando dados do gráfico...</p>
+    {:else if !errorMessage && !simulationResults}
+      <p>Preencha os parâmetros e clique em "Simular" para gerar o gráfico.</p>
+    {:else if !errorMessage && simulationResults && (!titrationCurveData || titrationCurveData.length === 0)}
+      <p>Não há dados suficientes na curva de titulação para desenhar o gráfico.</p>
+    {/if}
+  </section>
+</main>
+
+<style>
+  .chart-container {
+    width: 100%;
+    max-width: 700px;
+    margin: 20px auto;
+    background-color: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 10px;
+  }
+  svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+  .tick text {
+    fill: #555;
+  }
+  path {
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+</style>

--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/Sample.simulation.test.js
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/Sample.simulation.test.js
@@ -1,0 +1,1 @@
+// Placeholder for future tests


### PR DESCRIPTION
This commit introduces the frontend interface for the "Curva de Titulação Ácido-Base" simulation.

Key features include:
- A new Svelte page at `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`.
- A comprehensive input form allowing you to define:
    - Analyte (acid or base, name, concentration, volume, and Ka/Kb for weak species).
    - Titrant (type - acid/base, name, concentration).
    - Titration parameters (initial volume, final volume, and volume increment).
- API integration with the existing `/api/simulation/acid-base-titration/start` backend endpoint.
- Dynamic rendering of the titration curve (pH vs. titrant volume) using an SVG-based chart.
- Display of simulation summary messages and parameters used.
- User experience enhancements: loading indicators, error messages, and client-side input validation (e.g., for positive values, required fields, logical volume ranges).
- Updated `README.md` and `HANDOVER_DOCUMENT.md` to include details of the new experiment and its frontend implementation.

The new page follows the styling and structural conventions of existing experiment pages, utilizing Tailwind CSS and DaisyUI components.