### PR TITLE
Fix: Resolve mismatched main tag in acid-base-titration page

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -507,7 +507,6 @@
       </div>
     {/if}
   </section>
-</main>
 
 <style>
   .chart-container {


### PR DESCRIPTION
I removed a superfluous closing `</main>` tag from `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte` (previously at line 510). This tag was causing a Vite build error: "</main> attempted to close an element that was not open".

This commit aims to rectify the HTML structure and allow the build to proceed.