### PR TITLE
fix: Correct Svelte parsing error in titration page

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -356,7 +356,7 @@
     {/if}
 
     {#if simulationResults && !isLoading && !errorMessage}
-      <div class="mt-4 space-y-6"> {/* Increased spacing for better readability */}
+      <div class="mt-4 space-y-6">
         {#if simulationResults.message}
           <div class="alert alert-info shadow-lg">
             <div>


### PR DESCRIPTION
Removes a Svelte-style comment (`{/* ... */}`) that was improperly placed within an HTML tag definition in
`frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`.

The line:
`<div class="mt-4 space-y-6"> {/* Increased spacing for better readability */} ` was changed to:
`<div class="mt-4 space-y-6">`

This resolves the "Unexpected block closing tag" error reported by the Vite build process, which was likely caused by the parser misinterpreting the comment in that position.