### PR TITLE
Fix: Correct unclosed {#if} block in acid-base-titration page

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -507,6 +507,7 @@
       </div>
     {/if}
   </section>
+{/if}
 
 <style>
   .chart-container {


### PR DESCRIPTION
Addressed a "Block was left open" error in `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte` by adding a missing `{/if}` tag. The error was related to the `{#if isLoading || errorMessage || simulationResults}` block starting around line 340.

A brief review of event handlers in the vicinity was also conducted, and no obvious syntactical issues were found after the block structure was corrected.