### PR TITLE
Fix: Correct Svelte template structure and remove unused CSS

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -508,6 +508,7 @@
     {/if}
   </section>
 {/if}
+</main>
 
 <style>
   .chart-container {

--- a/frontend/src/routes/experiments/chemistry/acid-base/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base/+page.svelte
@@ -399,13 +399,6 @@
     border: 1px solid #ccc;
     border-radius: 4px;
   }
-  .ph-scale-container h4 {
-      margin-top: 0;
-      margin-bottom: 10px;
-      text-align: center;
-      font-weight: normal;
-      color: #555;
-  }
 
   .ph-bar {
     width: 100%;


### PR DESCRIPTION
This commit addresses multiple issues:

1.  In `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`:
    *   Restored the `</main>` tag that was previously incorrectly removed. This fixes the "`<main> was left open`" build error.
    *   Verified that the `{#if isLoading || errorMessage || simulationResults}` block remains correctly closed after other modifications.

2.  In `frontend/src/routes/experiments/chemistry/acid-base/+page.svelte`:
    *   Removed an unused CSS selector `.ph-scale-container h4` to eliminate a build warning.

These changes should ensure the Svelte templates are structurally sound and the build process is clean of these specific errors and warnings.