### PR TITLE
Fix: Prevent duplicate body read in acid-base titration error handling

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -182,11 +182,11 @@
 
       if (!response.ok) {
         let errorData;
+        const responseText = await response.text(); // Read body once as text
         try {
-          errorData = await response.json();
+          errorData = JSON.parse(responseText); // Try to parse as JSON
         } catch (e) {
-          const textError = await response.text();
-          errorData = { detail: textError || response.statusText };
+          errorData = { detail: responseText || response.statusText }; // Fallback to text
         }
         errorMessage = `Erro ${response.status}: ${errorData.detail || 'Ocorreu um erro desconhecido.'}`;
         if (errorData.errors) {


### PR DESCRIPTION
The `runSimulation` function in the acid-base titration page was attempting to read the response body twice in error scenarios (first with `response.json()`, then with `response.text()` if the former failed). This could lead to a "Body has already been consumed" error.

This commit modifies the error handling to read the response body as text once, then attempts to parse it as JSON. If JSON parsing fails, it uses the raw text for the error message. This ensures the response body is accessed only once, resolving the potential error.