### PR TITLE
Fix: Add Vite proxy for API requests in acid-base titration

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,15 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [sveltekit()]
+  plugins: [sveltekit()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000', // Assuming backend runs on port 8000
+        changeOrigin: true, // Recommended for virtual hosted sites
+        // You might not need rewrite if your backend paths are already /api/...
+        // rewrite: (path) => path.replace(/^\/api/, ''), // Use if backend doesn't expect /api prefix
+      }
+    }
+  }
 });


### PR DESCRIPTION
The acid-base titration simulation was resulting in a 404 error because API requests to `/api/...` were not being proxied from the Vite development server to the backend FastAPI server.

This commit adds a proxy configuration to `frontend/vite.config.js` to forward all requests made to `/api` to `http://localhost:8000` (the assumed backend address). This should allow the frontend to correctly communicate with the backend for the simulation.