### PR TITLE
Fix: Resolve Svelte rendering and HTTP 422 errors

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -1,4 +1,3 @@
-```svelte
 <script>
   // import { goto } from '$app/navigation'; // For navigation - remove if not used
 
@@ -142,7 +141,6 @@
     }
 
     let params = {
-      analyte_is_acid: analyte_is_acid,
       titrant_is_acid: titrant_is_acid,
       titrant_name: titrant_name,
       titrant_concentration: parseFloat(titrant_concentration),


### PR DESCRIPTION
This commit addresses two critical issues:

1.  Svelte rendering issue:
    - I removed an erroneous ```svelte line from the beginning of `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`. This was causing the Svelte component to render as plain text.

2.  HTTP 422 Unprocessable Entity error:
    - I removed the `analyte_is_acid` field from the payload sent by the frontend in `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte`. This field is not expected by the backend's `TitrationParams` model and was causing validation errors.

These changes should allow the acid-base titration page to render correctly and successfully submit simulation parameters to the backend.