### PR TITLE
Fix: Correct Ka/Kb parsing in acid-base titration

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -109,6 +109,16 @@
     }
   }
 
+  function parseOptionalFloat(value) {
+    if (value === null || String(value).trim() === "") {
+      return null;
+    }
+    const floatVal = parseFloat(value);
+    if (isNaN(floatVal)) {
+      return null;
+    }
+    return floatVal;
+  }
 
   async function runSimulation() {
     isLoading = true;
@@ -153,7 +163,7 @@
       params.acid_name = acid_name;
       params.acid_concentration = parseFloat(acid_concentration);
       params.acid_volume = parseFloat(acid_volume);
-      params.acid_ka = acid_ka ? acid_ka : null;
+      params.acid_ka = parseOptionalFloat(acid_ka);
       params.base_name = null;
       params.base_concentration = null;
       params.base_volume = null;
@@ -162,7 +172,7 @@
       params.base_name = base_name;
       params.base_concentration = parseFloat(base_concentration);
       params.base_volume = parseFloat(base_volume);
-      params.base_kb = base_kb ? base_kb : null;
+      params.base_kb = parseOptionalFloat(base_kb);
       params.acid_name = null;
       params.acid_concentration = null;
       params.acid_volume = null;


### PR DESCRIPTION
This commit addresses an issue in the acid-base titration simulation frontend where empty or invalid Ka/Kb values could cause a 422 Unprocessable Entity error from the backend.

The `runSimulation` function in `frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte` was modified:
- I implemented a helper function `parseOptionalFloat` to handle the conversion of Ka/Kb input strings.
- This function ensures that if Ka/Kb is an empty string, whitespace, or results in NaN after parsing, it is converted to `null` before being sent to the backend API.
- The backend expects `Optional[float]` for these fields, and `null` is the correct way to represent an omitted optional value in this context.

This change should prevent the 422 error when you leave the Ka or Kb fields empty or enter non-numeric text (which client-side validation should also catch but this provides backend robustness).