### PR TITLE
Fix: Make analyte concentration/volume optional in titration model

### DIFF
--- a/backend/simulations/chemistry/models_acid_base.py
+++ b/backend/simulations/chemistry/models_acid_base.py
@@ -4,13 +4,13 @@ from backend.simulations.base_simulation import BaseSimulationParams, BaseSimula
 
 class AcidBaseSimulationParams(BaseSimulationParams):
     acid_name: Optional[str] = Field(default="Ácido Forte", description="Nome do ácido (ex: HCl, H₂SO₄, CH₃COOH)")
-    acid_concentration: float = Field(gt=0, description="Concentração molar do ácido (mol/L)")
-    acid_volume: float = Field(gt=0, description="Volume de ácido a ser usado (mL)")
+    acid_concentration: Optional[float] = Field(default=None, gt=0, description="Concentração molar do ácido (mol/L)")
+    acid_volume: Optional[float] = Field(default=None, gt=0, description="Volume de ácido a ser usado (mL)")
     acid_ka: Optional[float] = Field(default=None, gt=0, description="Constante de ionização do ácido (Ka) para ácidos fracos")
 
     base_name: Optional[str] = Field(default="Base Forte", description="Nome da base (ex: NaOH, Ca(OH)₂, NH₃)")
-    base_concentration: float = Field(gt=0, description="Concentração molar da base (mol/L)")
-    base_volume: float = Field(gt=0, description="Volume de base a ser adicionado (mL)")
+    base_concentration: Optional[float] = Field(default=None, gt=0, description="Concentração molar da base (mol/L)")
+    base_volume: Optional[float] = Field(default=None, gt=0, description="Volume de base a ser adicionado (mL)")
     base_kb: Optional[float] = Field(default=None, gt=0, description="Constante de ionização da base (Kb) para bases fracas")
 
     indicator_name: Optional[str] = Field(default=None, description="Nome do indicador de pH (ex: Fenolftaleína, Vermelho de Metila)")


### PR DESCRIPTION
This commit addresses the persistent HTTP 422 Unprocessable Entity error you encountered during the acid-base titration simulation. The root cause was a mismatch between the frontend payload (which correctly sent `null` for non-applicable analyte parameters) and the backend Pydantic models (which incorrectly defined these parameters as non-optional).

Changes in `backend/simulations/chemistry/models_acid_base.py`:
- Modified the `AcidBaseSimulationParams` class.
- The fields `acid_concentration`, `acid_volume`, `base_concentration`, and `base_volume` have been changed from `float` to `Optional[float]` with `default=None`.

This change allows the backend to accept `null` values for these fields, aligning with the frontend's behavior of only providing values for the selected analyte (acid or base).

The responsibility for ensuring that the necessary analyte parameters (e.g., `acid_concentration` for an acid analyte) are actually provided for the simulation now rests within the specific simulation logic in `acid_base_titration_module.py`. This module should perform conditional checks and raise appropriate errors if required data for the chosen analyte is missing.