### PR TITLE
Debug: Temporarily set graph path stroke to red

### DIFF
--- a/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
+++ b/frontend/src/routes/experiments/chemistry/acid-base-titration/+page.svelte
@@ -504,7 +504,7 @@
           <text x={padding.left + (svgWidth - padding.left - padding.right) / 2} y={svgHeight - padding.bottom + 35} text-anchor="middle" font-size="12" class="fill-current font-semibold">Volume do Titulante Adicionado (mL)</text>
 
           <!-- Titration Curve Path -->
-          <path d={svgPathD} fill="none" stroke="var(--color-primary, oklch(var(--p)))" stroke-width="2" /> <!-- Using DaisyUI primary color variable -->
+          <path d={svgPathD} fill="none" stroke="red" stroke-width="2" /> <!-- Using DaisyUI primary color variable -->
 
         </svg>
       </div>


### PR DESCRIPTION
Changes the stroke color of the titration curve SVG path to a hardcoded "red". This is a temporary debugging step to determine if the issue of the graph line not appearing is due to the styling (e.g., the CSS variable for the stroke color not resolving to a visible color).

If the graph line now appears in red, it confirms a styling problem with the original `var(--color-primary)` stroke. Otherwise, the issue lies elsewhere.